### PR TITLE
Disable livekit-api on win-aarch64 & WebRTC Builds CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -18,6 +18,7 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: windows-latest
             target: aarch64-pc-windows-msvc
+            extraargs: --exclude livekit-api # livekit-api isn't compatible with windows arm64 (waiting for v0.17 of ring)
           - os: macos-latest
             target: x86_64-apple-darwin
           - os: macos-latest
@@ -36,17 +37,12 @@ jobs:
           rustup update --no-self-update stable
           rustup target add ${{ matrix.target }}
 
-      - if: ${{ matrix.target == 'aarch64-pc-windows-msvc' }}
-        run: |
-          echo "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" >> $GITHUB_PATH
-        shell: bash
-
       - uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Build
-        run: cargo build --release --verbose --target ${{ matrix.target }}
+        run: cargo build --workspace --release --verbose --target ${{ matrix.target }} ${{ matrix.extraargs }}
 
       - name: Build examples
         working-directory: examples

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            cmd: build-windows.cmd 
+            cmd: ./build-windows.cmd 
             artifacts: windows
           - os: ubuntu-latest
             cmd: ./build_linux.sh
@@ -18,7 +18,7 @@ jobs:
             cmd: ./build_macos.sh
             artifacts: macos
 
-    name: Build webrtc (${{ matrix.target }})
+    name: Build webrtc (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/ninja-build/ninja/releases/latest/download/ninja-win.zip" -OutFile ninja.zip
           Expand-Archive -Path ninja.zip -DestinationPath ninja
-          echo "$GITHUB_WORKSPACE\ninja" >> $GITHUB_PATH
+          echo "${{github.workspace}}/ninja" >> $GITHUB_PATH
 
       - name: Print ninja version
         run: ninja --version

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            cmd: ./build-windows.cmd 
+            cmd: .\build-windows.cmd 
             artifacts: windows
           - os: ubuntu-latest
             cmd: ./build_linux.sh
@@ -38,7 +38,7 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/ninja-build/ninja/releases/latest/download/ninja-win.zip" -OutFile ninja.zip
           Expand-Archive -Path ninja.zip -DestinationPath ninja
-          echo "${{github.workspace}}/ninja" >> $GITHUB_PATH
+          echo "${{github.workspace}}\ninja" >> $GITHUB_PATH
 
       - name: Print ninja version
         run: ninja --version

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            cmd: cmd /c build-windows.cmd 
+            cmd: .\build_windows.cmd 
             artifacts: windows
           - os: ubuntu-latest
             cmd: ./build_linux.sh

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -1,4 +1,4 @@
-name: Build webrtc
+name: WebRTC builds
 on: workflow_dispatch
 env:
   CARGO_TERM_COLOR: always
@@ -9,7 +9,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            cmd: .\build-windows.cmd 
+            cmd: cmd /c build-windows.cmd 
             artifacts: windows
           - os: ubuntu-latest
             cmd: ./build_linux.sh

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -45,9 +45,10 @@ jobs:
 
       - name: Build
         run: ${{ matrix.cmd }}
+        working-directory: webrtc-sys/libwebrtc
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: builds-${{ matrix.artifacts }}
-          path: ${{ matrix.artifacts }}
+          path: webrtc-sys/libwebrtc/${{ matrix.artifacts }}

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -1,0 +1,53 @@
+name: Build webrtc
+on: workflow_dispatch
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            cmd: build-windows.cmd 
+            artifacts: windows
+          - os: ubuntu-latest
+            cmd: ./build_linux.sh
+            artifacts: linux
+          - os: macos-latest
+            cmd: ./build_macos.sh
+            artifacts: macos
+
+    name: Build webrtc (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install linux dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo apt install -y ninja-build pkg-config
+
+      - name: Install macos dependencies
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: brew install ninja
+
+      - name: Install windows dependencies
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/ninja-build/ninja/releases/latest/download/ninja-win.zip" -OutFile ninja.zip
+          Expand-Archive -Path ninja.zip -DestinationPath ninja
+          echo "$GITHUB_WORKSPACE\ninja" >> $GITHUB_PATH
+
+      - name: Print ninja version
+        run: ninja --version
+
+      - name: Build
+        run: ${{ matrix.cmd }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: builds-${{ matrix.artifacts }}
+          path: ${{ matrix.artifacts }}


### PR DESCRIPTION
- Disable livekit-api (serversdk) builds for windows aarch64
     - Waiting for the ring crate to release v0.17 (jsonwebtokens needs to update it)
- Added WebRTC builds CI