### PR TITLE
fix: windows crashes & builds

### DIFF
--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/ninja-build/ninja/releases/latest/download/ninja-win.zip" -OutFile ninja.zip
           Expand-Archive -Path ninja.zip -DestinationPath ninja
-          echo "${{github.workspace}}\ninja" >> $GITHUB_PATH
+          echo "${{ github.workspace }}\ninja" >> $GITHUB_PATH
 
       - name: Print ninja version
         run: ninja --version
@@ -65,7 +65,9 @@ jobs:
 
       - name: Zip artifact (Unix)
         if: ${{ matrix.os != 'windows-latest' }}
-        run: zip ${{ steps.setup.outputs.ZIP }} webrtc-sys/libwebrtc/${{ steps.setup.outputs.OUT }}/* -r
+        run: |
+          cd webrtc-sys/libwebrtc/${{ steps.setup.outputs.OUT }}
+          zip ${{ github.workspace }}/${{ steps.setup.outputs.ZIP }} ./* -r
 
       - name: Zip artifact (Windows)
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -57,7 +57,7 @@ jobs:
         run: ${{ matrix.cmd }} --arch ${{ matrix.arch }} --profile ${{ matrix.profile }}
         working-directory: webrtc-sys/libwebrtc
 
-      - name: zip artifact for upload
+      - name: Zip artifact for upload
         run: zip artifact.zip webrtc-sys/libwebrtc/${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }}/* -r
 
       - name: Upload artifacts

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -35,6 +35,13 @@ jobs:
         run: |
           echo "OUT=${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }}" >> "$GITHUB_OUTPUT"
           echo "ZIP=webrtc-${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }}.zip" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      # Print some debug infos to be sure everything is ok before doing really long tasks..
+      - name: Info
+        run: |
+          echo "OutName: ${{ steps.setup.outputs.OUT }}"
+          echo "OutZip: ${{ steps.setup.outputs.ZIP }}"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -57,8 +57,11 @@ jobs:
         run: ${{ matrix.cmd }} --arch ${{ matrix.arch }} --profile ${{ matrix.profile }}
         working-directory: webrtc-sys/libwebrtc
 
+      - name: zip artifact for upload
+        run: zip artifact.zip webrtc-sys/libwebrtc/${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }}/* -r
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: webrtc-${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }} 
-          path: webrtc-sys/libwebrtc/${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }}
+          path: artifact.zip

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -30,6 +30,12 @@ jobs:
     name: Build webrtc (${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }})
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Setup vars
+        id: setup
+        run: |
+          echo "OUT=${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }}" >> "$GITHUB_OUTPUT"
+          echo "ZIP=webrtc-${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }}.zip" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v3
         with:
           submodules: true
@@ -57,11 +63,17 @@ jobs:
         run: ${{ matrix.cmd }} --arch ${{ matrix.arch }} --profile ${{ matrix.profile }}
         working-directory: webrtc-sys/libwebrtc
 
-      - name: Zip artifact for upload
-        run: zip artifact.zip webrtc-sys/libwebrtc/${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }}/* -r
+      - name: Zip artifact (Unix)
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: zip ${{ steps.setup.outputs.ZIP }} webrtc-sys/libwebrtc/${{ steps.setup.outputs.OUT }}/* -r
 
+      - name: Zip artifact (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: Compress-Archive -Path .\webrtc-sys\libwebrtc\${{ steps.setup.outputs.OUT }}\* -DestinationPath ${{ steps.setup.outputs.ZIP }}
+
+      # doublezip here but I don't think there is an alternative
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: webrtc-${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }} 
-          path: artifact.zip
+          name: ${{ steps.setup.outputs.ZIP }}
+          path: ${{ steps.setup.outputs.ZIP }}

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -6,25 +6,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        profile: ["release", "debug"] 
-        config:
-          - os: windows-latest
-            name: windows 
-            cmd: .\build_windows.cmd
-            archs: [x64, arm64]
-          - os: ubuntu-latest
-            name: linux
-            cmd: ./build_linux.sh
-            archs: [x64, arm64]
-          - os: macos-latest
-            name: macos
-            cmd: ./build_macos.sh
-            archs: [x64, arm64]
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+        arch:
+          - x64
+          - arm64
+        profile:
+          - release
+          - debug
         include:
-          - os: ${{ matrix.config.os }}
-            arch: ${{ matrix.config.archs }}
-            name: ${{ matrix.config.name }}
-            cmd: ${{ matrix.config.cmd }}
+          - os: windows-latest
+            cmd: .\build_windows.cmd
+            name: win
+          - os: ubuntu-latest
+            cmd: ./build_linux.sh
+            name: linux
+          - os: macos-latest
+            cmd: ./build_macos.sh
+            name: macos
 
     name: Build webrtc (${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -1,25 +1,32 @@
 name: WebRTC builds
 on: workflow_dispatch
-env:
-  CARGO_TERM_COLOR: always
 
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        include:
+        profile: ["release", "debug"] 
+        config:
           - os: windows-latest
-            cmd: .\build_windows.cmd 
-            artifacts: windows
+            name: windows 
+            cmd: .\build_windows.cmd
+            archs: [x64, arm64]
           - os: ubuntu-latest
+            name: linux
             cmd: ./build_linux.sh
-            artifacts: linux
+            archs: [x64, arm64]
           - os: macos-latest
+            name: macos
             cmd: ./build_macos.sh
-            artifacts: macos
+            archs: [x64, arm64]
+        include:
+          - os: ${{ matrix.config.os }}
+            arch: ${{ matrix.config.archs }}
+            name: ${{ matrix.config.name }}
+            cmd: ${{ matrix.config.cmd }}
 
-    name: Build webrtc (${{ matrix.os }})
+    name: Build webrtc (${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }})
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -34,6 +41,7 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         run: brew install ninja
 
+      # It doesn't seem to be used?
       - name: Install windows dependencies
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
@@ -44,12 +52,12 @@ jobs:
       - name: Print ninja version
         run: ninja --version
 
-      - name: Build
-        run: ${{ matrix.cmd }}
+      - name: Build WebRTC
+        run: ${{ matrix.cmd }} --arch ${{ matrix.arch }} --profile ${{ matrix.profile }}
         working-directory: webrtc-sys/libwebrtc
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: builds-${{ matrix.artifacts }}
-          path: webrtc-sys/libwebrtc/${{ matrix.artifacts }}
+          name: webrtc-${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }} 
+          path: webrtc-sys/libwebrtc/${{ matrix.name }}-${{ matrix.arch }}-${{ matrix.profile }}

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -6,8 +6,8 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         include:
           - os: windows-latest
             cmd: .\build_windows.cmd 

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
+        fail-fast: false
         include:
           - os: windows-latest
             cmd: .\build_windows.cmd 

--- a/livekit-webrtc/src/native/peer_connection.rs
+++ b/livekit-webrtc/src/native/peer_connection.rs
@@ -110,6 +110,7 @@ impl From<sys_pc::ffi::SignalingState> for SignalingState {
 
 #[derive(Clone)]
 pub struct PeerConnection {
+    #[allow(dead_code)]
     native_observer: SharedPtr<sys_pc::ffi::NativePeerConnectionObserver>,
     observer: Arc<PeerObserver>,
 

--- a/livekit-webrtc/src/native/rtp_parameters.rs
+++ b/livekit-webrtc/src/native/rtp_parameters.rs
@@ -1,5 +1,4 @@
 use crate::rtp_parameters::*;
-use crate::MediaType;
 use webrtc_sys::rtp_parameters as sys_rp;
 use webrtc_sys::webrtc as sys_webrtc;
 

--- a/livekit-webrtc/src/native/rtp_transceiver.rs
+++ b/livekit-webrtc/src/native/rtp_transceiver.rs
@@ -5,7 +5,6 @@ use crate::rtp_receiver;
 use crate::rtp_sender;
 use crate::rtp_transceiver::RtpTransceiverDirection;
 use crate::rtp_transceiver::RtpTransceiverInit;
-use crate::MediaType;
 use crate::RtcError;
 use cxx::SharedPtr;
 use webrtc_sys::rtc_error as sys_err;
@@ -33,7 +32,6 @@ impl From<RtpTransceiverDirection> for sys_webrtc::ffi::RtpTransceiverDirection 
             RtpTransceiverDirection::RecvOnly => Self::RecvOnly,
             RtpTransceiverDirection::Inactive => Self::Inactive,
             RtpTransceiverDirection::Stopped => Self::Stopped,
-            _ => panic!("unknown RtpTransceiverDirection"),
         }
     }
 }

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -102,9 +102,9 @@ fn main() {
     };
     println!("cargo:rerun-if-env-changed=LK_CUSTOM_WEBRTC");
 
-    let (webrtc_dir, webrtc_include, webrtc_lib) = if true {
+    let (webrtc_dir, webrtc_include, webrtc_lib) = if use_custom_webrtc {
         // Use a local WebRTC version (libwebrtc folder)
-        let webrtc_dir = path::PathBuf::from("./libwebrtc/macos");
+        let webrtc_dir = path::PathBuf::from("./libwebrtc");
         (
             webrtc_dir.clone(),
             webrtc_dir.join("include"),
@@ -192,7 +192,6 @@ fn main() {
         if IGNORE_DEFINES.contains(&define_name) {
             continue;
         }
-        panic!("Unknown define: {}", define_name);
         builder.define(define_name, define_value);
     }
 

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -1,17 +1,22 @@
 use regex::Regex;
 use std::env;
 use std::fs;
+use std::io::BufRead;
 use std::io::{self, Write};
 use std::path;
 use std::process::Command;
 
 const WEBRTC_TAG: &str = "webrtc-beb0471";
+const IGNORE_DEFINES: [&str; 2] = ["CR_CLANG_REVISION", "CR_XCODE_VERSION"];
 
 fn download_prebuilt_webrtc(
     out_path: path::PathBuf,
 ) -> Result<path::PathBuf, Box<dyn std::error::Error>> {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    // This is not yet supported on all platforms.
+    // On Windows, we need Rust to link against libcmtd.
     let use_debug = {
         let var = env::var("LK_DEBUG_WEBRTC");
         var.is_ok() && var.unwrap() == "true"
@@ -95,19 +100,26 @@ fn main() {
         let var = env::var("LK_CUSTOM_WEBRTC");
         var.is_ok() && var.unwrap() == "true"
     };
+    println!("cargo:rerun-if-env-changed=LK_CUSTOM_WEBRTC");
 
-    let (webrtc_include, webrtc_lib) = if use_custom_webrtc {
+    let (webrtc_dir, webrtc_include, webrtc_lib) = if true {
         // Use a local WebRTC version (libwebrtc folder)
-        let webrtc_dir = path::PathBuf::from("./libwebrtc");
-        (webrtc_dir.join("src"), webrtc_dir.join("src/out/Dev/obj"))
+        let webrtc_dir = path::PathBuf::from("./libwebrtc/macos");
+        (
+            webrtc_dir.clone(),
+            webrtc_dir.join("include"),
+            webrtc_dir.join("lib"),
+        )
     } else {
         // Download a prebuilt version of WebRTC
         let download_dir = env::var("OUT_DIR").unwrap() + "/webrtc-sdk";
         let webrtc_dir = download_prebuilt_webrtc(path::PathBuf::from(download_dir)).unwrap();
-
-        (webrtc_dir.join("include"), webrtc_dir.join("lib"))
+        (
+            webrtc_dir.clone(),
+            webrtc_dir.join("include"),
+            webrtc_dir.join("lib"),
+        )
     };
-    println!("cargo:rerun-if-env-changed=LK_CUSTOM_WEBRTC");
 
     // Just required for the bridge build to succeed.
     let includes = &[
@@ -140,23 +152,25 @@ fn main() {
         "src/helper.rs",
     ]);
 
-    builder.file("src/peer_connection.cpp");
-    builder.file("src/peer_connection_factory.cpp");
-    builder.file("src/media_stream.cpp");
-    builder.file("src/data_channel.cpp");
-    builder.file("src/jsep.cpp");
-    builder.file("src/candidate.cpp");
-    builder.file("src/rtp_receiver.cpp");
-    builder.file("src/rtp_sender.cpp");
-    builder.file("src/rtp_transceiver.cpp");
-    builder.file("src/rtp_parameters.cpp");
-    builder.file("src/rtc_error.cpp");
-    builder.file("src/webrtc.cpp");
-    builder.file("src/video_frame.cpp");
-    builder.file("src/video_frame_buffer.cpp");
-    builder.file("src/video_encoder_factory.cpp");
-    builder.file("src/video_decoder_factory.cpp");
-    builder.file("src/audio_device.cpp");
+    builder.files(&[
+        "src/peer_connection.cpp",
+        "src/peer_connection_factory.cpp",
+        "src/media_stream.cpp",
+        "src/data_channel.cpp",
+        "src/jsep.cpp",
+        "src/candidate.cpp",
+        "src/rtp_receiver.cpp",
+        "src/rtp_sender.cpp",
+        "src/rtp_transceiver.cpp",
+        "src/rtp_parameters.cpp",
+        "src/rtc_error.cpp",
+        "src/webrtc.cpp",
+        "src/video_frame.cpp",
+        "src/video_frame_buffer.cpp",
+        "src/video_encoder_factory.cpp",
+        "src/video_decoder_factory.cpp",
+        "src/audio_device.cpp",
+    ]);
 
     for include in includes {
         builder.include(include);
@@ -166,6 +180,21 @@ fn main() {
         "cargo:rustc-link-search=native={}",
         webrtc_lib.canonicalize().unwrap().to_str().unwrap()
     );
+
+    // Read preprocessor definitions from webrtc.ninja
+    let webrtc_gni = fs::File::open(webrtc_dir.join("webrtc.ninja")).unwrap();
+    let mut reader = io::BufReader::new(webrtc_gni).lines();
+    let defines_line = reader.next().unwrap().unwrap(); // The first line contains the defines
+    let defines_re = Regex::new(r"-D(\w+)(?:=([^\s]+))?").unwrap();
+    for cap in defines_re.captures_iter(&defines_line) {
+        let define_name = &cap[1];
+        let define_value = cap.get(2).map(|m| m.as_str());
+        if IGNORE_DEFINES.contains(&define_name) {
+            continue;
+        }
+        panic!("Unknown define: {}", define_name);
+        builder.define(define_name, define_value);
+    }
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     match target_os.as_str() {
@@ -186,12 +215,7 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=dwmapi");
             println!("cargo:rustc-link-lib=static=webrtc");
 
-            builder
-                .flag("/std:c++17")
-                .flag("/EHsc")
-                .define("WEBRTC_WIN", None)
-                //.define("WEBRTC_ENABLE_SYMBOL_EXPORT", None) Not necessary when using WebRTC as a static library
-                .define("NOMINMAX", None);
+            builder.flag("/std:c++17").flag("/EHsc");
         }
         "linux" => {
             println!("cargo:rustc-link-lib=dylib=Xext");
@@ -203,10 +227,7 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=m");
             println!("cargo:rustc-link-lib=static=webrtc");
 
-            builder
-                .flag("-std=c++17")
-                .define("WEBRTC_POSIX", None)
-                .define("WEBRTC_LINUX", None);
+            builder.flag("-std=c++17");
         }
         "macos" => {
             println!("cargo:rustc-link-lib=framework=Foundation");
@@ -254,19 +275,10 @@ fn main() {
             builder
                 .flag("-stdlib=libc++")
                 .flag("-std=c++17")
-                .flag(format!("-isysroot{}", sysroot).as_str())
-                .define("WEBRTC_ENABLE_OBJC_SYMBOL_EXPORT", None)
-                .define("WEBRTC_POSIX", None)
-                .define("WEBRTC_MAC", None);
+                .flag(format!("-isysroot{}", sysroot).as_str());
         }
         "ios" => {
-            builder
-                .flag("-std=c++17")
-                .file("src/objc_test.mm")
-                .define("WEBRTC_ENABLE_OBJC_SYMBOL_EXPORT", None)
-                .define("WEBRTC_MAC", None)
-                .define("WEBRTC_POSIX", None)
-                .define("WEBRTC_IOS", None);
+            builder.flag("-std=c++17");
         }
         "android" => {
             let ndk_env = env::var("ANDROID_NDK_HOME").expect(
@@ -330,11 +342,7 @@ fn main() {
                 vs_path.to_str().unwrap()
             );
 
-            builder
-                .flag("-std=c++17")
-                .define("WEBRTC_LINUX", None)
-                .define("WEBRTC_POSIX", None)
-                .define("WEBRTC_ANDROID", None);
+            builder.flag("-std=c++17");
         }
         _ => {
             panic!("Unsupported target, {}", target_os);

--- a/webrtc-sys/libwebrtc/.gitignore
+++ b/webrtc-sys/libwebrtc/.gitignore
@@ -5,6 +5,6 @@ depot_tools
 ninja
 
 # builds
-win-*
-macos-*
-linux-*
+win*
+macos*
+linux*

--- a/webrtc-sys/libwebrtc/.gitignore
+++ b/webrtc-sys/libwebrtc/.gitignore
@@ -2,7 +2,9 @@
 src
 .gclient_*
 depot_tools
+ninja
 
 # builds
-macos
-linux
+win-*
+macos-*
+linux-*

--- a/webrtc-sys/libwebrtc/build_linux.sh
+++ b/webrtc-sys/libwebrtc/build_linux.sh
@@ -98,7 +98,8 @@ gn gen "$OUTPUT_DIR" --root="src" --args="${args}"
 ninja -C "$OUTPUT_DIR" :default
 
 # make libwebrtc.a
-ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" `find "$OUTPUT_DIR/obj" -name '*.o'`
+# don't include nasm
+ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*"`
 
 python3 "./src/tools_webrtc/libs/generate_licenses.py" \
   --target :default "$OUTPUT_DIR" "$OUTPUT_DIR"

--- a/webrtc-sys/libwebrtc/build_linux.sh
+++ b/webrtc-sys/libwebrtc/build_linux.sh
@@ -1,5 +1,42 @@
 #!/bin/bash
 
+arch=""
+profile="release"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --arch)
+      arch="$2"
+      if [ "$arch" != "x64" ] && [ "$arch" != "arm64" ]; then
+        echo "Error: Invalid value for --arch. Must be 'x64' or 'arm64'."
+        exit 1
+      fi
+      shift 2
+      ;;
+    --profile)
+      profile="$2"
+      if [ "$profile" != "debug" ] && [ "$profile" != "release" ]; then
+        echo "Error: Invalid value for --profile. Must be 'debug' or 'release'."
+        exit 1
+      fi
+      shift 2
+      ;;
+    *)
+      echo "Error: Unknown argument '$1'"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$arch" ]; then
+  echo "Error: --arch must be set."
+  exit 1
+fi
+
+echo "Building LiveKit WebRTC"
+echo "Arch: $arch"
+echo "Profile: $profile"
+
 if [ ! -e "$(pwd)/depot_tools" ]
 then
   git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
@@ -8,70 +45,73 @@ fi
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
 export OUTPUT_DIR="$(pwd)/src/out"
-export ARTIFACTS_DIR="$(pwd)/linux"
+export ARTIFACTS_DIR="$(pwd)/linux-$arch-$profile"
 
 if [ ! -e "$(pwd)/src" ]
 then
-  gclient sync
+  gclient sync -D --no-history
 fi
 
 cd src
-git apply "$COMMAND_DIR/patches/add_license_dav1d.patch" -v
-git apply "$COMMAND_DIR/patches/ssl_verify_callback_with_native_handle.patch" -v
-git apply "$COMMAND_DIR/patches/fix_mocks.patch" -v
+git apply "$COMMAND_DIR/patches/add_license_dav1d.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+git apply "$COMMAND_DIR/patches/ssl_verify_callback_with_native_handle.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+git apply "$COMMAND_DIR/patches/fix_mocks.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 cd ..
 
 mkdir -p "$ARTIFACTS_DIR/lib"
 
-for is_debug in "true" "false"
-do
-  for target_cpu in "x64" "arm64"
-  do
-    args="is_debug=${is_debug} \
-      target_os=\"linux\" \
-      target_cpu=\"${target_cpu}\" \
-      rtc_enable_protobuf=false \
-      treat_warnings_as_errors=false \
-      use_custom_libcxx=false \
-      rtc_include_tests=false \
-      rtc_build_tools=false \
-      rtc_build_examples=false \
-      rtc_libvpx_build_vp9=true \
-      is_component_build=false \
-      enable_stripping=true \
-      use_goma=false \
-      rtc_use_h264=false \
-      rtc_use_pipewire=false \
-      symbol_level=0 \
-      enable_iterator_debugging=false \
-      use_rtti=true \
-      rtc_use_x11=false"
+python3 "./src/build/linux/sysroot_scripts/install-sysroot.py" --arch="$arch"
 
-    if [ $is_debug = "true" ]; then
-      args="${args} is_asan=true is_lsan=true";
-    fi
+debug="false"
+if [ "$profile" = "debug" ]; then
+  debug="true"
+fi
 
-    # generate ninja files
-    gn gen "$OUTPUT_DIR" --root="src" --args="${args}"
+args="is_debug=$debug  \
+  target_os=\"linux\" \
+  target_cpu=\"$arch\" \
+  rtc_enable_protobuf=false \
+  treat_warnings_as_errors=false \
+  use_custom_libcxx=false \
+  rtc_include_tests=false \
+  rtc_build_tools=false \
+  rtc_build_examples=false \
+  rtc_libvpx_build_vp9=true \
+  is_component_build=false \
+  enable_stripping=true \
+  use_goma=false \
+  rtc_use_h264=false \
+  rtc_use_pipewire=false \
+  symbol_level=0 \
+  enable_iterator_debugging=false \
+  use_rtti=true \
+  rtc_use_x11=false"
 
-    # build static library
-    ninja -C "$OUTPUT_DIR" webrtc
+if [ "$debug" = "true" ]; then
+  args="${args} is_asan=true is_lsan=true";
+fi
 
-    filename="libwebrtc.a"
-    if [ $is_debug = "true" ]; then
-      filename="libwebrtcd.a"
-    fi
+# generate ninja files
+gn gen "$OUTPUT_DIR" --root="src" --args="${args}"
 
-    # cppy static library
-    mkdir -p "$ARTIFACTS_DIR/lib/${target_cpu}"
-    cp "$OUTPUT_DIR/obj/libwebrtc.a" "$ARTIFACTS_DIR/lib/${target_cpu}/${filename}"
-  done
-done
+# build static library
+ninja -C "$OUTPUT_DIR" :default
+
+filename="libwebrtc.a"
+if [ "$debug" = "true" ]; then
+  filename="libwebrtcd.a"
+fi
+
+# make libwebrtc.a
+ar -rc "$ARTIFACTS_DIR/lib/$filename" `find "$OUTPUT_DIR/obj" -name '*.o'`
 
 python3 "./src/tools_webrtc/libs/generate_licenses.py" \
-  --target :webrtc "$OUTPUT_DIR" "$OUTPUT_DIR"
+  --target :default "$OUTPUT_DIR" "$OUTPUT_DIR"
+
+cp "$OUTPUT_DIR/obj/webrtc.ninja" "$ARTIFACTS_DIR"
+cp "$OUTPUT_DIR/args.gn" "$ARTIFACTS_DIR"
+cp "$OUTPUT_DIR/LICENSE.md" "$ARTIFACTS_DIR"
 
 cd src
 find . -name "*.h" -print | cpio -pd "$ARTIFACTS_DIR/include"
 
-cp "$OUTPUT_DIR/LICENSE.md" "$ARTIFACTS_DIR"

--- a/webrtc-sys/libwebrtc/build_linux.sh
+++ b/webrtc-sys/libwebrtc/build_linux.sh
@@ -97,13 +97,8 @@ gn gen "$OUTPUT_DIR" --root="src" --args="${args}"
 # build static library
 ninja -C "$OUTPUT_DIR" :default
 
-filename="libwebrtc.a"
-if [ "$debug" = "true" ]; then
-  filename="libwebrtcd.a"
-fi
-
 # make libwebrtc.a
-ar -rc "$ARTIFACTS_DIR/lib/$filename" `find "$OUTPUT_DIR/obj" -name '*.o'`
+ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" `find "$OUTPUT_DIR/obj" -name '*.o'`
 
 python3 "./src/tools_webrtc/libs/generate_licenses.py" \
   --target :default "$OUTPUT_DIR" "$OUTPUT_DIR"

--- a/webrtc-sys/libwebrtc/build_linux.sh
+++ b/webrtc-sys/libwebrtc/build_linux.sh
@@ -44,7 +44,7 @@ fi
 
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
-export OUTPUT_DIR="$(pwd)/src/out"
+export OUTPUT_DIR="$(pwd)/src/out-$arch-$profile"
 export ARTIFACTS_DIR="$(pwd)/linux-$arch-$profile"
 
 if [ ! -e "$(pwd)/src" ]

--- a/webrtc-sys/libwebrtc/build_macos.sh
+++ b/webrtc-sys/libwebrtc/build_macos.sh
@@ -99,7 +99,7 @@ ninja -C "$OUTPUT_DIR" :default \
   sdk:mac_framework_objc
 
 # make libwebrtc.a
-# don't include nasm (on macos x86_64, there is two main fnc)
+# don't include nasm
 ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*"`
 
 python3 "./src/tools_webrtc/libs/generate_licenses.py" \

--- a/webrtc-sys/libwebrtc/build_macos.sh
+++ b/webrtc-sys/libwebrtc/build_macos.sh
@@ -1,4 +1,41 @@
-#!/bin/bash -eu
+#!/bin/bash
+
+arch=""
+profile="release"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --arch)
+      arch="$2"
+      if [ "$arch" != "x64" ] && [ "$arch" != "arm64" ]; then
+        echo "Error: Invalid value for --arch. Must be 'x64' or 'arm64'."
+        exit 1
+      fi
+      shift 2
+      ;;
+    --profile)
+      profile="$2"
+      if [ "$profile" != "debug" ] && [ "$profile" != "release" ]; then
+        echo "Error: Invalid value for --profile. Must be 'debug' or 'release'."
+        exit 1
+      fi
+      shift 2
+      ;;
+    *)
+      echo "Error: Unknown argument '$1'"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$arch" ]; then
+  echo "Error: --arch must be set."
+  exit 1
+fi
+
+echo "Building LiveKit WebRTC"
+echo "Arch: $arch"
+echo "Profile: $profile"
 
 if [ ! -e "$(pwd)/depot_tools" ]
 then
@@ -8,76 +45,75 @@ fi
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
 export OUTPUT_DIR="$(pwd)/src/out"
-export ARTIFACTS_DIR="$(pwd)/macos"
+export ARTIFACTS_DIR="$(pwd)/macos-$arch-$profile"
 
 if [ ! -e "$(pwd)/src" ]
 then
-  gclient sync
+  gclient sync -D --no-history
 fi
 
 cd src
-git apply "$COMMAND_DIR/patches/add_license_dav1d.patch" -v
-git apply "$COMMAND_DIR/patches/ssl_verify_callback_with_native_handle.patch" -v
-git apply "$COMMAND_DIR/patches/fix_mocks.patch" -v
+git apply "$COMMAND_DIR/patches/add_license_dav1d.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+git apply "$COMMAND_DIR/patches/ssl_verify_callback_with_native_handle.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+git apply "$COMMAND_DIR/patches/fix_mocks.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 cd ..
 
 mkdir -p "$ARTIFACTS_DIR/lib"
 
-for is_debug in "true" "false"
-do
-  for target_cpu in "x64" "arm64"
-  do
+debug="false"
+if [ "$profile" = "debug" ]; then
+  debug="true"
+fi
 
-    # generate ninja files
-    gn gen "$OUTPUT_DIR" --root="src" \
-      --args="is_debug=${is_debug} \
-      enable_dsyms=${is_debug} \
-      target_os=\"mac\"  \
-      target_cpu=\"${target_cpu}\" \
-      mac_deployment_target=\"10.11\" \
-      treat_warnings_as_errors=false \
-      rtc_enable_protobuf=false \
-      rtc_include_tests=false \
-      rtc_build_examples=false \
-      rtc_build_tools=false \
-      rtc_libvpx_build_vp9=true \
-      is_component_build=false \
-      enable_stripping=true \
-      rtc_enable_symbol_export=true \
-      rtc_enable_objc_symbol_export=false \
-      rtc_use_h264=false \
-      use_custom_libcxx=false \
-      clang_use_chrome_plugins=false \
-      use_rtti=true \
-      use_lld=false"
+# generate ninja files
+gn gen "$OUTPUT_DIR" --root="src" \
+  --args="is_debug=$debug \
+  enable_dsyms=$debug \
+  target_os=mac \
+  target_cpu=\"$arch\" \
+  mac_deployment_target=\"10.11\" \
+  treat_warnings_as_errors=false \
+  rtc_enable_protobuf=false \
+  rtc_include_tests=false \
+  rtc_build_examples=false \
+  rtc_build_tools=false \
+  rtc_libvpx_build_vp9=true \
+  is_component_build=false \
+  enable_stripping=true \
+  rtc_enable_symbol_export=true \
+  rtc_enable_objc_symbol_export=false \
+  rtc_use_h264=false \
+  use_custom_libcxx=false \
+  clang_use_chrome_plugins=false \
+  use_rtti=true \
+  use_lld=false"
 
-    # build static library
-    ninja -C "$OUTPUT_DIR" :default \
-      api/audio_codecs:builtin_audio_decoder_factory \
-      api/task_queue:default_task_queue_factory \
-      sdk:native_api \
-      sdk:default_codec_factory_objc \
-      pc:peerconnection \
-      sdk:videocapture_objc \
-      sdk:mac_framework_objc
+# build static library
+ninja -C "$OUTPUT_DIR" :default \
+  api/audio_codecs:builtin_audio_decoder_factory \
+  api/task_queue:default_task_queue_factory \
+  sdk:native_api \
+  sdk:default_codec_factory_objc \
+  pc:peerconnection \
+  sdk:videocapture_objc \
+  sdk:mac_framework_objc
 
-    filename="libwebrtc.a"
-    if [ $is_debug = "true" ]; then
-      filename="libwebrtcd.a"
-    fi
+filename="libwebrtc.a"
+if [ "$debug" = "true" ]; then
+  filename="libwebrtcd.a"
+fi
 
-    # make libwebrtc.a
-    mkdir -p "$ARTIFACTS_DIR/lib/${target_cpu}"
-
-    # don't include nasm (on macos x86_64, there is two main fnc)
-    ar -rc "$ARTIFACTS_DIR/lib/${target_cpu}/${filename}" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*"`
-  done
-done
+# make libwebrtc.a
+# don't include nasm (on macos x86_64, there is two main fnc)
+ar -rc "$ARTIFACTS_DIR/lib/$filename" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*"`
 
 python3 "./src/tools_webrtc/libs/generate_licenses.py" \
   --target :webrtc "$OUTPUT_DIR" "$OUTPUT_DIR"
 
+cp "$OUTPUT_DIR/obj/webrtc.ninja" "$ARTIFACTS_DIR"
+cp "$OUTPUT_DIR/args.gn" "$ARTIFACTS_DIR"
+cp "$OUTPUT_DIR/LICENSE.md" "$ARTIFACTS_DIR"
+
 cd src
 find . -name "*.h" -print | cpio -pd "$ARTIFACTS_DIR/include"
 
-cp "$OUTPUT_DIR/LICENSE.md" "$ARTIFACTS_DIR"

--- a/webrtc-sys/libwebrtc/build_macos.sh
+++ b/webrtc-sys/libwebrtc/build_macos.sh
@@ -44,7 +44,7 @@ fi
 
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
-export OUTPUT_DIR="$(pwd)/src/out"
+export OUTPUT_DIR="$(pwd)/src/out-$arch-$profile"
 export ARTIFACTS_DIR="$(pwd)/macos-$arch-$profile"
 
 if [ ! -e "$(pwd)/src" ]

--- a/webrtc-sys/libwebrtc/build_macos.sh
+++ b/webrtc-sys/libwebrtc/build_macos.sh
@@ -43,26 +43,33 @@ do
       rtc_libvpx_build_vp9=true \
       is_component_build=false \
       enable_stripping=true \
-      use_goma=false \
-      rtc_use_h264=false \
       rtc_enable_symbol_export=true \
       rtc_enable_objc_symbol_export=false \
+      rtc_use_h264=false \
+      use_custom_libcxx=false \
       clang_use_chrome_plugins=false \
-      symbol_level=0 \
-      enable_iterator_debugging=false \
-      use_rtti=true"
+      use_rtti=true \
+      use_lld=false"
 
     # build static library
-    ninja -C "$OUTPUT_DIR" webrtc
+    ninja -C "$OUTPUT_DIR" api/audio_codecs:builtin_audio_decoder_factory \
+      api/task_queue:default_task_queue_factory \
+      sdk:native_api \
+      sdk:default_codec_factory_objc \
+      pc:peerconnection \
+      sdk:videocapture_objc \
+      sdk:mac_framework_objc
 
     filename="libwebrtc.a"
     if [ $is_debug = "true" ]; then
       filename="libwebrtcd.a"
     fi
 
-    # cppy static library
+    # make libwebrtc.a
     mkdir -p "$ARTIFACTS_DIR/lib/${target_cpu}"
-    cp "$OUTPUT_DIR/obj/libwebrtc.a" "$ARTIFACTS_DIR/lib/${target_cpu}/${filename}"
+
+    # don't include nasm (on macos x86_64, there is two main fnc)
+    ar -rc "$ARTIFACTS_DIR/lib/${target_cpu}/${filename}" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*"`
   done
 done
 

--- a/webrtc-sys/libwebrtc/build_macos.sh
+++ b/webrtc-sys/libwebrtc/build_macos.sh
@@ -69,7 +69,7 @@ fi
 gn gen "$OUTPUT_DIR" --root="src" \
   --args="is_debug=$debug \
   enable_dsyms=$debug \
-  target_os=mac \
+  target_os=\"mac\" \
   target_cpu=\"$arch\" \
   mac_deployment_target=\"10.11\" \
   treat_warnings_as_errors=false \
@@ -98,14 +98,9 @@ ninja -C "$OUTPUT_DIR" :default \
   sdk:videocapture_objc \
   sdk:mac_framework_objc
 
-filename="libwebrtc.a"
-if [ "$debug" = "true" ]; then
-  filename="libwebrtcd.a"
-fi
-
 # make libwebrtc.a
 # don't include nasm (on macos x86_64, there is two main fnc)
-ar -rc "$ARTIFACTS_DIR/lib/$filename" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*"`
+ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*"`
 
 python3 "./src/tools_webrtc/libs/generate_licenses.py" \
   --target :webrtc "$OUTPUT_DIR" "$OUTPUT_DIR"

--- a/webrtc-sys/libwebrtc/build_macos.sh
+++ b/webrtc-sys/libwebrtc/build_macos.sh
@@ -52,7 +52,8 @@ do
       use_lld=false"
 
     # build static library
-    ninja -C "$OUTPUT_DIR" api/audio_codecs:builtin_audio_decoder_factory \
+    ninja -C "$OUTPUT_DIR" :default \
+      api/audio_codecs:builtin_audio_decoder_factory \
       api/task_queue:default_task_queue_factory \
       sdk:native_api \
       sdk:default_codec_factory_objc \

--- a/webrtc-sys/libwebrtc/build_windows.cmd
+++ b/webrtc-sys/libwebrtc/build_windows.cmd
@@ -1,5 +1,7 @@
 @echo off
 
+setlocal enabledelayedexpansion
+
 set arch=
 set profile=release
 
@@ -21,7 +23,7 @@ if not "!arch!" == "x64" if not "!arch!" == "arm64" (
     echo Error: Invalid value for --arch. Must be 'x64' or 'arm64'.
     exit /b 1
 )
-if not "!profile!" == "true" if not "!profile!" == "false" (
+if not "!profile!" == "debug" if not "!profile!" == "release" (
     echo Error: Invalid value for --profile. Must be 'debug' or 'release'.
     exit /b 1
 )

--- a/webrtc-sys/libwebrtc/build_windows.cmd
+++ b/webrtc-sys/libwebrtc/build_windows.cmd
@@ -42,7 +42,7 @@ set DEPOT_TOOLS_WIN_TOOLCHAIN=0
 set GYP_GENERATORS=ninja,msvs-ninja
 set GYP_MSVS_VERSION=2019
 set OUTPUT_DIR=src/out
-set ARTIFACTS_DIR=%cd%\windows-!arch!-!profile!
+set ARTIFACTS_DIR=%cd%\win-!arch!-!profile!
 set vs2019_install=C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional
 
 if not exist src (
@@ -69,15 +69,8 @@ call gn.bat gen %OUTPUT_DIR% --root="src" ^
 rem build
 ninja.exe -C %OUTPUT_DIR% :default
 
-set filename=
-if "!debug!"=="true" (
-  set filename=webrtcd.lib
-) else (
-  set filename=webrtc.lib
-)
-
 rem copy static library for release build
-copy "%OUTPUT_DIR%\obj\webrtc.lib" "%ARTIFACTS_DIR%\lib\!filename!"
+copy "%OUTPUT_DIR%\obj\webrtc.lib" "%ARTIFACTS_DIR%\lib"
 
 rem generate license
 call python3 "%cd%\src\tools_webrtc\libs\generate_licenses.py" ^

--- a/webrtc-sys/libwebrtc/build_windows.cmd
+++ b/webrtc-sys/libwebrtc/build_windows.cmd
@@ -1,5 +1,35 @@
 @echo off
 
+set arch=
+set profile=release
+
+:arg_loop
+if "%1" == "" goto end_arg_loop
+if "%1" == "--arch" (
+    set "arch=%2"
+    shift & shift & goto arg_loop
+)
+if "%1" == "--profile" (
+    set "profile=%2"
+    shift & shift & goto arg_loop
+)
+echo Error: Unknown argument '%1'
+exit /b 1
+:end_arg_loop
+
+if not "!arch!" == "x64" if not "!arch!" == "arm64" (
+    echo Error: Invalid value for --arch. Must be 'x64' or 'arm64'.
+    exit /b 1
+)
+if not "!profile!" == "true" if not "!profile!" == "false" (
+    echo Error: Invalid value for --profile. Must be 'debug' or 'release'.
+    exit /b 1
+)
+
+echo "Building LiveKit WebRTC"
+echo "Arch: !arch!"
+echo "Profile: !profile!"
+
 if not exist depot_tools (
   git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
 )
@@ -10,7 +40,7 @@ set DEPOT_TOOLS_WIN_TOOLCHAIN=0
 set GYP_GENERATORS=ninja,msvs-ninja
 set GYP_MSVS_VERSION=2019
 set OUTPUT_DIR=src/out
-set ARTIFACTS_DIR=%cd%\windows
+set ARTIFACTS_DIR=%cd%\windows-!arch!-!profile!
 set vs2019_install=C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional
 
 if not exist src (
@@ -18,46 +48,38 @@ if not exist src (
 )
 
 cd src
-call git apply "%COMMAND_DIR%/patches/add_license_dav1d.patch" -v
-call git apply "%COMMAND_DIR%/patches/ssl_verify_callback_with_native_handle.patch" -v
-call git apply "%COMMAND_DIR%/patches/fix_mocks.patch" -v
+call git apply "%COMMAND_DIR%/patches/add_license_dav1d.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+call git apply "%COMMAND_DIR%/patches/ssl_verify_callback_with_native_handle.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+call git apply "%COMMAND_DIR%/patches/fix_mocks.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 cd ..
 
 mkdir "%ARTIFACTS_DIR%\lib"
 
-setlocal enabledelayedexpansion
+rem generate ninja for release
+call gn.bat gen %OUTPUT_DIR% --root="src" ^
+  --args="is_debug=!debug! is_clang=true target_cpu=\"!arch!\" use_custom_libcxx=false rtc_include_tests=false rtc_build_examples=false rtc_build_tools=false is_component_build=false rtc_enable_protobuf=false rtc_use_h264=false symbol_level=0 enable_iterator_debugging=false"
 
-for %%i in (x64 arm64) do (
-  mkdir "%ARTIFACTS_DIR%/lib/%%i"
-  for %%j in (true false) do (
+rem build
+ninja.exe -C %OUTPUT_DIR% :default
 
-    rem generate ninja for release
-    call gn.bat gen %OUTPUT_DIR% --root="src" ^
-      --args="is_debug=%%j is_clang=true target_cpu=\"%%i\" use_custom_libcxx=false rtc_include_tests=false rtc_build_examples=false rtc_use_h264=false symbol_level=0 enable_iterator_debugging=false"
-
-    rem build
-    ninja.exe -C %OUTPUT_DIR% webrtc
-
-    set filename=
-    if true==%%j (
-      set filename=webrtcd.lib
-    ) else (
-      set filename=webrtc.lib
-    )
-
-    rem copy static library for release build
-    copy "%OUTPUT_DIR%\obj\webrtc.lib" "%ARTIFACTS_DIR%\lib\%%i\!filename!"
-  )
+set filename=
+if "!debug!"=="true" (
+  set filename=webrtcd.lib
+) else (
+  set filename=webrtc.lib
 )
 
-endlocal
+rem copy static library for release build
+copy "%OUTPUT_DIR%\obj\webrtc.lib" "%ARTIFACTS_DIR%\lib\!filename!"
 
 rem generate license
 call python3 "%cd%\src\tools_webrtc\libs\generate_licenses.py" ^
-  --target :webrtc %OUTPUT_DIR% %OUTPUT_DIR%
+  --target :default %OUTPUT_DIR% %OUTPUT_DIR%
+
+copy "%OUTPUT_DIR%\obj\webrtc.ninja" "%ARTIFACTS_DIR%"
+copy "%OUTPUT_DIR%\args.gn" "%ARTIFACTS_DIR%"
+copy "%OUTPUT_DIR%\LICENSE.md" "%ARTIFACTS_DIR%"
 
 rem copy header
 xcopy src\*.h "%ARTIFACTS_DIR%\include" /C /S /I /F /H
 
-rem copy license
-copy "%OUTPUT_DIR%\LICENSE.md" "%ARTIFACTS_DIR%\LICENSE.md"

--- a/webrtc-sys/libwebrtc/build_windows.cmd
+++ b/webrtc-sys/libwebrtc/build_windows.cmd
@@ -41,7 +41,7 @@ set PATH=%cd%\depot_tools;%PATH%
 set DEPOT_TOOLS_WIN_TOOLCHAIN=0
 set GYP_GENERATORS=ninja,msvs-ninja
 set GYP_MSVS_VERSION=2019
-set OUTPUT_DIR=src/out
+set OUTPUT_DIR=src\out-!arch!-!profile!
 set ARTIFACTS_DIR=%cd%\win-!arch!-!profile!
 set vs2019_install=C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional
 

--- a/webrtc-sys/libwebrtc/build_windows.cmd
+++ b/webrtc-sys/libwebrtc/build_windows.cmd
@@ -57,6 +57,11 @@ cd ..
 
 mkdir "%ARTIFACTS_DIR%\lib"
 
+set "debug=false"
+if "!profile!" == "debug" (
+  set "debug=true"
+)
+
 rem generate ninja for release
 call gn.bat gen %OUTPUT_DIR% --root="src" ^
   --args="is_debug=!debug! is_clang=true target_cpu=\"!arch!\" use_custom_libcxx=false rtc_include_tests=false rtc_build_examples=false rtc_build_tools=false is_component_build=false rtc_enable_protobuf=false rtc_use_h264=false symbol_level=0 enable_iterator_debugging=false"

--- a/webrtc-sys/libwebrtc/build_windows.cmd
+++ b/webrtc-sys/libwebrtc/build_windows.cmd
@@ -14,7 +14,7 @@ set ARTIFACTS_DIR=%cd%\windows
 set vs2019_install=C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional
 
 if not exist src (
-  call gclient.bat sync
+  call gclient.bat sync -D --no-history
 )
 
 cd src


### PR DESCRIPTION
- Doing jobs in parallels in [GHA](https://github.com/theomonnom/client-sdk-rust/actions/runs/4765787387/jobs/8471968034) (Divide build time by 3).
- Now use custom webrtc builds for this repo
- Windows crashes when receiving video is now fixed (thanks @cloudwebrtc)
    - Now reading defines from webrtc.ninja
- Added a small create_pc test to be sure libwebrtc is working/linked correctly 
- Fix MacOS builds 
- Fixed Linux duplicated main build error (due to nasm)

Debug builds of webrtc are still not supported inside the Rust SDK (even if we're still building them). On Windows, Rust never links against libcmtd... (Pending/Draft [PR](https://github.com/rust-lang/libc/pull/3178)). Not tested for other platforms