### PR TITLE
Add proto3 optional to prost build

### DIFF
--- a/livekit-ffi/build.rs
+++ b/livekit-ffi/build.rs
@@ -1,7 +1,9 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
-    prost_build::compile_protos(
+    let mut prost_build = prost_build::Config::new();
+    prost_build.protoc_arg("--experimental_allow_proto3_optional");
+    prost_build.compile_protos(
         &[
             "protocol/ffi.proto",
             "protocol/handle.proto",

--- a/livekit-protocol/build.rs
+++ b/livekit-protocol/build.rs
@@ -2,6 +2,7 @@ use std::io::Result;
 
 fn main() -> Result<()> {
     let mut prost_build = prost_build::Config::new();
+    prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.compile_protos(
         &[
             "protocol/livekit_egress.proto",


### PR DESCRIPTION
Adding this `protoc` option to the `prost` build fixes a build error I received when building in Ubuntu containers:

```
#0 117.3 error: failed to run custom build command for `livekit-protocol v0.1.0 (https://github.com/livekit/client-sdk-rust.git?rev=a5caf12#a5caf129)`
#0 117.3 
#0 117.3 Caused by:
#0 117.3   process didn't exit successfully: `/usr/src/rtsp-publisher/target/release/build/livekit-protocol-11624bcec5533409/build-script-build` (exit status: 1)
#0 117.3   --- stderr
#0 117.3   Error: Custom { kind: Other, error: "protoc failed: livekit_room.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.\n" }
```

I didn't see the issue on Mac, but the build is still working with the change.