### PR TITLE
fix: datachannel deadlocks & dispose crashes

### DIFF
--- a/livekit-webrtc/src/native/peer_connection_factory.rs
+++ b/livekit-webrtc/src/native/peer_connection_factory.rs
@@ -115,6 +115,12 @@ impl PeerConnectionFactory {
     }
 }
 
+impl Drop for PeerConnectionFactory {
+    fn drop(&mut self) {
+        println!("{:?}", self.sys_handle);
+    }
+}
+
 // Conversions
 impl From<IceServer> for sys_pcf::ffi::IceServer {
     fn from(value: IceServer) -> Self {

--- a/livekit-webrtc/src/native/peer_connection_factory.rs
+++ b/livekit-webrtc/src/native/peer_connection_factory.rs
@@ -159,18 +159,3 @@ impl From<RtcConfiguration> for sys_pcf::ffi::RtcConfiguration {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_peer_connection_factory() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
-        let factory = PeerConnectionFactory::default();
-        let source = NativeVideoSource::default();
-        let _track = factory.create_video_track("test", source);
-        drop(factory);
-    }
-}

--- a/livekit-webrtc/src/native/peer_connection_factory.rs
+++ b/livekit-webrtc/src/native/peer_connection_factory.rs
@@ -115,12 +115,6 @@ impl PeerConnectionFactory {
     }
 }
 
-impl Drop for PeerConnectionFactory {
-    fn drop(&mut self) {
-        println!("{:?}", self.sys_handle);
-    }
-}
-
 // Conversions
 impl From<IceServer> for sys_pcf::ffi::IceServer {
     fn from(value: IceServer) -> Self {

--- a/livekit-webrtc/src/native/peer_connection_factory.rs
+++ b/livekit-webrtc/src/native/peer_connection_factory.rs
@@ -159,3 +159,18 @@ impl From<RtcConfiguration> for sys_pcf::ffi::RtcConfiguration {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_peer_connection_factory() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let factory = PeerConnectionFactory::default();
+        let source = NativeVideoSource::default();
+        let _track = factory.create_video_track("test", source);
+        drop(factory);
+    }
+}

--- a/livekit-webrtc/src/peer_connection.rs
+++ b/livekit-webrtc/src/peer_connection.rs
@@ -318,6 +318,8 @@ mod tests {
         println!("===========");
 
         alice.close();
+        println!("alice closed");
         bob.close();
+        println!("bob closed")
     }
 }

--- a/livekit-webrtc/src/peer_connection.rs
+++ b/livekit-webrtc/src/peer_connection.rs
@@ -317,7 +317,9 @@ mod tests {
         assert_eq!(data_rx.recv().await.unwrap(), "This is a test");
         println!("===========");
 
+        alice.close();
         println!("alice closed");
+        bob.close();
         println!("bob closed")
     }
 }

--- a/livekit-webrtc/src/peer_connection.rs
+++ b/livekit-webrtc/src/peer_connection.rs
@@ -269,20 +269,20 @@ mod tests {
         let bob = factory.create_peer_connection(config.clone()).unwrap();
         let alice = factory.create_peer_connection(config.clone()).unwrap();
 
-        let (bob_ice_tx, mut bob_ice_rx) = mpsc::channel::<IceCandidate>(16);
-        let (alice_ice_tx, mut alice_ice_rx) = mpsc::channel::<IceCandidate>(16);
-        let (alice_dc_tx, mut alice_dc_rx) = mpsc::channel::<DataChannel>(16);
+        let (bob_ice_tx, mut bob_ice_rx) = mpsc::unbounded_channel::<IceCandidate>();
+        let (alice_ice_tx, mut alice_ice_rx) = mpsc::unbounded_channel::<IceCandidate>();
+        let (alice_dc_tx, mut alice_dc_rx) = mpsc::unbounded_channel::<DataChannel>();
 
         bob.on_ice_candidate(Some(Box::new(move |candidate| {
-            bob_ice_tx.blocking_send(candidate).unwrap();
+            bob_ice_tx.send(candidate).unwrap();
         })));
 
         alice.on_ice_candidate(Some(Box::new(move |candidate| {
-            alice_ice_tx.blocking_send(candidate).unwrap();
+            alice_ice_tx.send(candidate).unwrap();
         })));
 
         alice.on_data_channel(Some(Box::new(move |dc| {
-            alice_dc_tx.blocking_send(dc).unwrap();
+            alice_dc_tx.send(dc).unwrap();
         })));
 
         let bob_dc = bob

--- a/livekit-webrtc/src/peer_connection.rs
+++ b/livekit-webrtc/src/peer_connection.rs
@@ -247,13 +247,9 @@ mod tests {
     use log::trace;
     use tokio::sync::mpsc;
 
-    fn init_log() {
-        let _ = env_logger::builder().is_test(true).try_init();
-    }
-
     #[tokio::test]
     async fn create_pc() {
-        init_log();
+        let _ = env_logger::builder().is_test(true).try_init();
 
         let factory = PeerConnectionFactory::default();
         let config = RtcConfiguration {
@@ -315,11 +311,8 @@ mod tests {
 
         bob_dc.send(b"This is a test", true).unwrap();
         assert_eq!(data_rx.recv().await.unwrap(), "This is a test");
-        println!("===========");
 
         alice.close();
-        println!("alice closed");
         bob.close();
-        println!("bob closed")
     }
 }

--- a/livekit-webrtc/src/peer_connection.rs
+++ b/livekit-webrtc/src/peer_connection.rs
@@ -317,9 +317,7 @@ mod tests {
         assert_eq!(data_rx.recv().await.unwrap(), "This is a test");
         println!("===========");
 
-        alice.close();
         println!("alice closed");
-        bob.close();
         println!("bob closed")
     }
 }

--- a/livekit-webrtc/src/peer_connection.rs
+++ b/livekit-webrtc/src/peer_connection.rs
@@ -305,16 +305,17 @@ mod tests {
         bob.add_ice_candidate(alice_ice).await.unwrap();
         alice.add_ice_candidate(bob_ice).await.unwrap();
 
-        let (data_tx, mut data_rx) = mpsc::channel::<String>(1);
+        let (data_tx, mut data_rx) = mpsc::unbounded_channel::<String>();
         let alice_dc = alice_dc_rx.recv().await.unwrap();
         alice_dc.on_message(Some(Box::new(move |buffer| {
             data_tx
-                .blocking_send(String::from_utf8_lossy(buffer.data).to_string())
+                .send(String::from_utf8_lossy(buffer.data).to_string())
                 .unwrap();
         })));
 
         bob_dc.send(b"This is a test", true).unwrap();
         assert_eq!(data_rx.recv().await.unwrap(), "This is a test");
+        println!("===========");
 
         alice.close();
         bob.close();

--- a/webrtc-sys/include/livekit/data_channel.h
+++ b/webrtc-sys/include/livekit/data_channel.h
@@ -40,6 +40,7 @@ class DataChannel {
   explicit DataChannel(
       std::shared_ptr<RtcRuntime> rtc_runtime,
       rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel);
+  ~DataChannel();
 
   void register_observer(rust::Box<DataChannelObserverWrapper> observer) const;
   void unregister_observer() const;
@@ -63,8 +64,6 @@ class NativeDataChannelObserver : public webrtc::DataChannelObserver {
  public:
   NativeDataChannelObserver(rust::Box<DataChannelObserverWrapper> observer,
                             const DataChannel* dc);
-
-  ~NativeDataChannelObserver();
 
   void OnStateChange() override;
   void OnMessage(const webrtc::DataBuffer& buffer) override;

--- a/webrtc-sys/include/livekit/peer_connection.h
+++ b/webrtc-sys/include/livekit/peer_connection.h
@@ -48,6 +48,8 @@ class PeerConnection {
       std::unique_ptr<NativePeerConnectionObserver> observer,
       rtc::scoped_refptr<webrtc::PeerConnectionInterface> peer_connection);
 
+  ~PeerConnection();
+
   void create_offer(
       RtcOfferAnswerOptions options,
       rust::Box<AsyncContext> ctx,

--- a/webrtc-sys/include/livekit/peer_connection_factory.h
+++ b/webrtc-sys/include/livekit/peer_connection_factory.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "api/peer_connection_interface.h"
+#include "api/scoped_refptr.h"
+#include "livekit/audio_device.h"
 #include "media_stream.h"
 #include "peer_connection.h"
 #include "rtp_parameters.h"
@@ -57,6 +59,7 @@ class PeerConnectionFactory {
 
  private:
   std::shared_ptr<RtcRuntime> rtc_runtime_;
+  rtc::scoped_refptr<AudioDevice> audio_device_;
   rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> peer_factory_;
 };
 

--- a/webrtc-sys/include/livekit/webrtc.h
+++ b/webrtc-sys/include/livekit/webrtc.h
@@ -80,6 +80,8 @@ class RtcRuntime : public std::enable_shared_from_this<RtcRuntime> {
   // have one livekit::VideoTrack associated with it).
   // The only reason we to do that is to allow to add states inside our
   // wrappers (e.g: the sinks_ member inside AudioTrack)
+  // DataChannel and the PeerConnectionFactory don't need to do this (There's no
+  // way to retrieve them after creation)
   webrtc::Mutex mutex_;
   std::vector<std::weak_ptr<MediaStreamTrack>> media_stream_tracks_;
   // We don't have additonal state in RtpReceiver and RtpSender atm..

--- a/webrtc-sys/include/livekit/webrtc.h
+++ b/webrtc-sys/include/livekit/webrtc.h
@@ -87,9 +87,9 @@ class RtcRuntime : public std::enable_shared_from_this<RtcRuntime> {
   // std::vector<std::weak_ptr<RtpSender>> rtp_senders_;
 
 #ifdef WEBRTC_WIN
-  rtc::WinsockInitializer winsock_;
-  rtc::PhysicalSocketServer ss_;
-  rtc::AutoSocketServerThread main_thread_{&ss_};
+  // rtc::WinsockInitializer winsock_;
+  // rtc::PhysicalSocketServer ss_;
+  // rtc::AutoSocketServerThread main_thread_{&ss_};
 #endif
 };
 

--- a/webrtc-sys/src/data_channel.cpp
+++ b/webrtc-sys/src/data_channel.cpp
@@ -47,6 +47,10 @@ DataChannel::DataChannel(
     rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel)
     : rtc_runtime_(rtc_runtime), data_channel_(std::move(data_channel)) {}
 
+DataChannel::~DataChannel() {
+  unregister_observer();
+}
+
 void DataChannel::register_observer(
     rust::Box<DataChannelObserverWrapper> observer) const {
   webrtc::MutexLock lock(&mutex_);
@@ -85,10 +89,6 @@ NativeDataChannelObserver::NativeDataChannelObserver(
     rust::Box<DataChannelObserverWrapper> observer,
     const DataChannel* dc)
     : observer_(std::move(observer)), dc_(dc) {}
-
-NativeDataChannelObserver::~NativeDataChannelObserver() {
-  // dc_->unregister_observer();
-}
 
 void NativeDataChannelObserver::OnStateChange() {
   observer_->on_state_change(dc_->state());

--- a/webrtc-sys/src/data_channel.cpp
+++ b/webrtc-sys/src/data_channel.cpp
@@ -87,7 +87,7 @@ NativeDataChannelObserver::NativeDataChannelObserver(
     : observer_(std::move(observer)), dc_(dc) {}
 
 NativeDataChannelObserver::~NativeDataChannelObserver() {
-  dc_->unregister_observer();
+  // dc_->unregister_observer();
 }
 
 void NativeDataChannelObserver::OnStateChange() {

--- a/webrtc-sys/src/peer_connection.cpp
+++ b/webrtc-sys/src/peer_connection.cpp
@@ -25,6 +25,7 @@
 #include "livekit/media_stream.h"
 #include "livekit/rtc_error.h"
 #include "livekit/rtp_transceiver.h"
+#include "rtc_base/logging.h"
 #include "webrtc-sys/src/peer_connection.rs.h"
 #include "webrtc-sys/src/rtc_error.rs.h"
 
@@ -51,11 +52,11 @@ PeerConnection::PeerConnection(
     : rtc_runtime_(rtc_runtime),
       observer_(std::move(observer)),
       peer_connection_(std::move(peer_connection)) {
-  RTC_LOG(LS_INFO) << "PeerConnection::PeerConnection()";
+  RTC_LOG(LS_VERBOSE) << "PeerConnection::PeerConnection()";
 }
 
 PeerConnection::~PeerConnection() {
-  RTC_LOG(LS_INFO) << "PeerConnection::~PeerConnection()";
+  RTC_LOG(LS_VERBOSE) << "PeerConnection::~PeerConnection()";
 }
 
 void PeerConnection::create_offer(

--- a/webrtc-sys/src/peer_connection.cpp
+++ b/webrtc-sys/src/peer_connection.cpp
@@ -50,7 +50,13 @@ PeerConnection::PeerConnection(
     rtc::scoped_refptr<webrtc::PeerConnectionInterface> peer_connection)
     : rtc_runtime_(rtc_runtime),
       observer_(std::move(observer)),
-      peer_connection_(std::move(peer_connection)) {}
+      peer_connection_(std::move(peer_connection)) {
+  RTC_LOG(LS_INFO) << "PeerConnection::PeerConnection()";
+}
+
+PeerConnection::~PeerConnection() {
+  RTC_LOG(LS_INFO) << "PeerConnection::~PeerConnection()";
+}
 
 void PeerConnection::create_offer(
     RtcOfferAnswerOptions options,

--- a/webrtc-sys/src/peer_connection_factory.cpp
+++ b/webrtc-sys/src/peer_connection_factory.cpp
@@ -70,7 +70,7 @@ webrtc::PeerConnectionInterface::RTCConfiguration to_native_rtc_configuration(
 PeerConnectionFactory::PeerConnectionFactory(
     std::shared_ptr<RtcRuntime> rtc_runtime)
     : rtc_runtime_(rtc_runtime) {
-  RTC_LOG(LS_INFO) << "PeerConnectionFactory::PeerConnectionFactory()";
+  RTC_LOG(LS_VERBOSE) << "PeerConnectionFactory::PeerConnectionFactory()";
 
   webrtc::PeerConnectionFactoryDependencies dependencies;
   dependencies.network_thread = rtc_runtime_->network_thread();
@@ -114,7 +114,7 @@ PeerConnectionFactory::PeerConnectionFactory(
 }
 
 PeerConnectionFactory::~PeerConnectionFactory() {
-  RTC_LOG(LS_INFO) << "PeerConnectionFactory::~PeerConnectionFactory()";
+  RTC_LOG(LS_VERBOSE) << "PeerConnectionFactory::~PeerConnectionFactory()";
 }
 
 std::shared_ptr<PeerConnection> PeerConnectionFactory::create_peer_connection(

--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -16,7 +16,9 @@
 
 #include "livekit/webrtc.h"
 
+#include <algorithm>
 #include <atomic>
+#include <iostream>
 #include <memory>
 
 #include "livekit/audio_track.h"
@@ -68,6 +70,8 @@ RtcRuntime::~RtcRuntime() {
       rtc::ThreadManager::Instance()->SetCurrentThread(nullptr);
     }
   }
+
+  std::cout << "FERGERGJIJEKGBWEBNGJKGEWJKGEWGJKBWEGJKWE" << std::endl;
 
   worker_thread_->Stop();
   signaling_thread_->Stop();

--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -38,6 +38,7 @@ namespace livekit {
 static uint32_t g_release_counter(0);
 
 RtcRuntime::RtcRuntime() {
+  rtc::LogMessage::LogToDebug(rtc::LS_INFO);
   RTC_LOG(LS_VERBOSE) << "RtcRuntime()";
 
   {
@@ -141,11 +142,11 @@ std::shared_ptr<VideoTrack> RtcRuntime::get_or_create_video_track(
 LogSink::LogSink(
     rust::Fn<void(rust::String message, LoggingSeverity severity)> fnc)
     : fnc_(fnc) {
-  rtc::LogMessage::AddLogToStream(this, rtc::LoggingSeverity::LS_VERBOSE);
+  // rtc::LogMessage::AddLogToStream(this, rtc::LoggingSeverity::LS_VERBOSE);
 }
 
 LogSink::~LogSink() {
-  rtc::LogMessage::RemoveLogToStream(this);
+  // rtc::LogMessage::RemoveLogToStream(this);
 }
 
 void LogSink::OnLogMessage(const std::string& message,

--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -63,6 +63,7 @@ RtcRuntime::RtcRuntime() {
 RtcRuntime::~RtcRuntime() {
   RTC_LOG(LS_VERBOSE) << "~RtcRuntime()";
 
+  std::cout << "FERGERGJIJEKGBWEBNGJKGEWJKGEWGJKBWEGJKWE" << std::endl;
   {
     // webrtc::MutexLock lock(&g_mutex);
     g_release_counter--;

--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -36,7 +36,7 @@ namespace livekit {
 static uint32_t g_release_counter(0);
 
 RtcRuntime::RtcRuntime() {
-  RTC_LOG(LS_INFO) << "RtcRuntime()";
+  RTC_LOG(LS_VERBOSE) << "RtcRuntime()";
 
   {
     // webrtc::MutexLock lock(&g_mutex);
@@ -58,7 +58,7 @@ RtcRuntime::RtcRuntime() {
 }
 
 RtcRuntime::~RtcRuntime() {
-  RTC_LOG(LS_INFO) << "~RtcRuntime()";
+  RTC_LOG(LS_VERBOSE) << "~RtcRuntime()";
 
   {
     // webrtc::MutexLock lock(&g_mutex);

--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -153,11 +153,11 @@ std::shared_ptr<VideoTrack> RtcRuntime::get_or_create_video_track(
 LogSink::LogSink(
     rust::Fn<void(rust::String message, LoggingSeverity severity)> fnc)
     : fnc_(fnc) {
-  // rtc::LogMessage::AddLogToStream(this, rtc::LoggingSeverity::LS_VERBOSE);
+  rtc::LogMessage::AddLogToStream(this, rtc::LoggingSeverity::LS_VERBOSE);
 }
 
 LogSink::~LogSink() {
-  // rtc::LogMessage::RemoveLogToStream(this);
+  rtc::LogMessage::RemoveLogToStream(this);
 }
 
 void LogSink::OnLogMessage(const std::string& message,

--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -30,16 +30,16 @@
 
 namespace livekit {
 
-static webrtc::Mutex g_mutex{};
-// Can't be atomic, we're using a Mutex because we need to wait for the
-// execution of the first init
+// static webrtc::Mutex g_mutex{};
+//  Can't be atomic, we're using a Mutex because we need to wait for the
+//  execution of the first init
 static uint32_t g_release_counter(0);
 
 RtcRuntime::RtcRuntime() {
   RTC_LOG(LS_INFO) << "RtcRuntime()";
 
   {
-    webrtc::MutexLock lock(&g_mutex);
+    // webrtc::MutexLock lock(&g_mutex);
     if (g_release_counter == 0) {
       RTC_CHECK(rtc::InitializeSSL()) << "Failed to InitializeSSL()";
     }
@@ -61,7 +61,7 @@ RtcRuntime::~RtcRuntime() {
   RTC_LOG(LS_INFO) << "~RtcRuntime()";
 
   {
-    webrtc::MutexLock lock(&g_mutex);
+    // webrtc::MutexLock lock(&g_mutex);
     g_release_counter--;
     if (g_release_counter == 0) {
       RTC_CHECK(rtc::CleanupSSL()) << "Failed to CleanupSSL()";

--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -65,14 +65,13 @@ RtcRuntime::~RtcRuntime() {
     g_release_counter--;
     if (g_release_counter == 0) {
       RTC_CHECK(rtc::CleanupSSL()) << "Failed to CleanupSSL()";
+      rtc::ThreadManager::Instance()->SetCurrentThread(nullptr);
     }
   }
 
-  // rtc::ThreadManager::Instance()->SetCurrentThread(nullptr);
-
-  worker_thread_->Quit();
-  signaling_thread_->Quit();
-  network_thread_->Quit();
+  worker_thread_->Stop();
+  signaling_thread_->Stop();
+  network_thread_->Stop();
 }
 
 rtc::Thread* RtcRuntime::network_thread() const {

--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -32,7 +32,7 @@ namespace livekit {
 
 static webrtc::Mutex g_mutex{};
 // Can't be atomic, we're using a Mutex because we need to wait for the
-// execution of the first init on other threads
+// execution of the first init
 static uint32_t g_release_counter(0);
 
 RtcRuntime::RtcRuntime() {
@@ -138,11 +138,11 @@ std::shared_ptr<VideoTrack> RtcRuntime::get_or_create_video_track(
 LogSink::LogSink(
     rust::Fn<void(rust::String message, LoggingSeverity severity)> fnc)
     : fnc_(fnc) {
-  // rtc::LogMessage::AddLogToStream(this, rtc::LoggingSeverity::LS_VERBOSE);
+  rtc::LogMessage::AddLogToStream(this, rtc::LoggingSeverity::LS_VERBOSE);
 }
 
 LogSink::~LogSink() {
-  // rtc::LogMessage::RemoveLogToStream(this);
+  rtc::LogMessage::RemoveLogToStream(this);
 }
 
 void LogSink::OnLogMessage(const std::string& message,

--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -32,7 +32,7 @@ namespace livekit {
 
 static webrtc::Mutex g_mutex{};
 // Can't be atomic, we're using a Mutex because we need to wait for the
-// execution of the first init
+// execution of the first init on other threads
 static uint32_t g_release_counter(0);
 
 RtcRuntime::RtcRuntime() {
@@ -138,11 +138,11 @@ std::shared_ptr<VideoTrack> RtcRuntime::get_or_create_video_track(
 LogSink::LogSink(
     rust::Fn<void(rust::String message, LoggingSeverity severity)> fnc)
     : fnc_(fnc) {
-  rtc::LogMessage::AddLogToStream(this, rtc::LoggingSeverity::LS_VERBOSE);
+  // rtc::LogMessage::AddLogToStream(this, rtc::LoggingSeverity::LS_VERBOSE);
 }
 
 LogSink::~LogSink() {
-  rtc::LogMessage::RemoveLogToStream(this);
+  // rtc::LogMessage::RemoveLogToStream(this);
 }
 
 void LogSink::OnLogMessage(const std::string& message,


### PR DESCRIPTION
- Fix datachannel deadlock on dispose
- Fix audio device being disposed on the wrong thread
- Allow multiple RtcRuntime to be created (Useful for unit tests where we use multiple PeerConnectionFactory)