### PR TITLE
feat: refactor events

### DIFF
--- a/livekit/src/lib.rs
+++ b/livekit/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 pub mod proto;
 mod room;
 mod rtc_engine;

--- a/livekit/src/prelude.rs
+++ b/livekit/src/prelude.rs
@@ -8,7 +8,7 @@ pub use crate::publication::{LocalTrackPublication, RemoteTrackPublication, Trac
 
 pub use crate::track::{
     AudioTrack, LocalAudioTrack, LocalTrack, LocalVideoTrack, RemoteAudioTrack, RemoteTrack,
-    RemoteVideoTrack, StreamState, Track, TrackKind, TrackSource, VideoTrack,
+    RemoteVideoTrack, StreamState, Track, TrackDimension, TrackKind, TrackSource, VideoTrack,
 };
 
 pub use crate::id::*;

--- a/livekit/src/prelude.rs
+++ b/livekit/src/prelude.rs
@@ -8,7 +8,7 @@ pub use crate::publication::{LocalTrackPublication, RemoteTrackPublication, Trac
 
 pub use crate::track::{
     AudioTrack, LocalAudioTrack, LocalTrack, LocalVideoTrack, RemoteAudioTrack, RemoteTrack,
-    RemoteVideoTrack, StreamState, Track, TrackEvent, TrackKind, TrackSource, VideoTrack,
+    RemoteVideoTrack, StreamState, Track, TrackKind, TrackSource, VideoTrack,
 };
 
 pub use crate::id::*;

--- a/livekit/src/prelude.rs
+++ b/livekit/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use crate::participant::{LocalParticipant, Participant, ParticipantEvent, RemoteParticipant};
+pub use crate::participant::{LocalParticipant, Participant, RemoteParticipant};
 
 pub use crate::{
     ConnectionState, DataPacketKind, Room, RoomError, RoomEvent, RoomOptions, RoomResult,

--- a/livekit/src/proto.rs
+++ b/livekit/src/proto.rs
@@ -1,7 +1,17 @@
-use crate::{track, DataPacketKind};
+use crate::{participant, track, DataPacketKind};
 use livekit_protocol::*;
 
 // Conversions
+impl From<ConnectionQuality> for participant::ConnectionQuality {
+    fn from(value: ConnectionQuality) -> Self {
+        match value {
+            ConnectionQuality::Excellent => Self::Excellent,
+            ConnectionQuality::Good => Self::Good,
+            ConnectionQuality::Poor => Self::Poor,
+        }
+    }
+}
+
 impl TryFrom<TrackType> for track::TrackKind {
     type Error = &'static str;
 

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -562,30 +562,34 @@ impl RoomSession {
             metadata,
         );
 
-        participant.on_track_published(|participant, publication| {
-            let _ = self.dispatcher.dispatch(&RoomEvent::TrackPublished {
+        let dispatcher = self.dispatcher.clone();
+        participant.on_track_published(move |participant, publication| {
+            dispatcher.dispatch(&RoomEvent::TrackPublished {
                 participant,
                 publication,
             });
         });
 
-        participant.on_track_unpublished(|participant, publication| {
-            let _ = self.dispatcher.dispatch(&RoomEvent::TrackUnpublished {
+        let dispatcher = self.dispatcher.clone();
+        participant.on_track_unpublished(move |participant, publication| {
+            dispatcher.dispatch(&RoomEvent::TrackUnpublished {
                 participant,
                 publication,
             });
         });
 
-        participant.on_track_subscribed(|participant, track, publication| {
-            let _ = self.dispatcher.dispatch(&RoomEvent::TrackSubscribed {
+        let dispatcher = self.dispatcher.clone();
+        participant.on_track_subscribed(move |participant, track, publication| {
+            dispatcher.dispatch(&RoomEvent::TrackSubscribed {
                 participant,
                 track,
                 publication,
             });
         });
 
-        participant.on_track_unsubscribed(|participant, track, publication| {
-            let _ = self.dispatcher.dispatch(&RoomEvent::TrackUnsubscribed {
+        let dispatcher = self.dispatcher.clone();
+        participant.on_track_unsubscribed(move |participant, track, publication| {
+            dispatcher.dispatch(&RoomEvent::TrackUnsubscribed {
                 participant,
                 track,
                 publication,

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -311,7 +311,7 @@ impl RoomSession {
     }
 
     /// Forward participant events to the room dispatcher
-    async fn participant_task(
+    /*async fn participant_task(
         self: Arc<Self>,
         participant: Participant,
         mut participant_events: mpsc::UnboundedReceiver<ParticipantEvent>,
@@ -372,7 +372,7 @@ impl RoomSession {
         }
 
         Ok(())
-    }
+    }*/
 
     async fn on_engine_event(self: &Arc<Self>, event: EngineEvent) -> RoomResult<()> {
         match event {

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -37,10 +37,22 @@ pub enum RoomError {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum RoomEvent {
     ParticipantConnected(RemoteParticipant),
     ParticipantDisconnected(RemoteParticipant),
+    LocalTrackPublished {
+        publication: LocalTrackPublication,
+    },
+    LocalTrackUnpublished {
+        publication: LocalTrackPublication,
+    },
     TrackSubscribed {
+        track: RemoteTrack,
+        publication: RemoteTrackPublication,
+        participant: RemoteParticipant,
+    },
+    TrackUnsubscribed {
         track: RemoteTrack,
         publication: RemoteTrackPublication,
         participant: RemoteParticipant,
@@ -50,11 +62,6 @@ pub enum RoomEvent {
         participant: RemoteParticipant,
     },
     TrackUnpublished {
-        publication: RemoteTrackPublication,
-        participant: RemoteParticipant,
-    },
-    TrackUnsubscribed {
-        track: RemoteTrack,
         publication: RemoteTrackPublication,
         participant: RemoteParticipant,
     },
@@ -178,7 +185,6 @@ impl Room {
                 metadata: room_info.metadata,
             }),
             participants: Default::default(),
-            participants_tasks: Default::default(),
             active_speakers: Default::default(),
             rtc_engine,
             local_participant,
@@ -268,7 +274,7 @@ pub(crate) struct RoomSession {
     active_speakers: RwLock<Vec<Participant>>,
     local_participant: LocalParticipant,
     participants: RwLock<HashMap<ParticipantSid, RemoteParticipant>>,
-    participants_tasks: RwLock<HashMap<ParticipantSid, (JoinHandle<()>, oneshot::Sender<()>)>>,
+    //participants_tasks: RwLock<HashMap<ParticipantSid, (JoinHandle<()>, oneshot::Sender<()>)>>,
 }
 
 impl Debug for RoomSession {
@@ -432,7 +438,7 @@ impl RoomSession {
                         participant: participant.clone(),
                     });
 
-                    participant.on_data_received(payload, kind);
+                    //participant.on_data_received(payload, kind);
                 }
             }
             EngineEvent::SpeakersChanged { speakers } => self.handle_speakers_changed(speakers),

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -121,8 +121,7 @@ impl LocalParticipant {
             .create_sender(track.clone(), options, encodings)
             .await?;
 
-        track.update_transceiver(Some(transceiver));
-        //track.start();
+        track.set_transceiver(Some(transceiver));
         track.enable();
 
         tokio::spawn({
@@ -158,14 +157,14 @@ impl LocalParticipant {
                 .rtc_engine
                 .remove_track(sender)
                 .await?;
-            track.update_transceiver(None);
+            track.set_transceiver(None);
 
             if let Some(local_track_unpublished) = &self.inner.events.read().local_track_unpublished
             {
                 local_track_unpublished(publication.clone());
             }
 
-            // publication.update_track(None);
+            //publication.set_track(None);
 
             tokio::spawn({
                 let rtc_engine = self.inner.participant_inner.rtc_engine.clone();

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -50,10 +50,13 @@ impl Participant {
         pub fn connection_quality(self: &Self) -> ConnectionQuality;
         pub fn tracks(self: &Self) -> RwLockReadGuard<HashMap<TrackSid, TrackPublication>>;
 
+
+        pub(crate) fn update_info(self: &Self, info: proto::ParticipantInfo) -> ();
+
+        // Internal functions called by the Room when receiving the associated signal messages
         pub(crate) fn set_speaking(self: &Self, speaking: bool) -> ();
         pub(crate) fn set_audio_level(self: &Self, level: f32) -> ();
         pub(crate) fn set_connection_quality(self: &Self, quality: ConnectionQuality) -> ();
-        pub(crate) fn update_info(self: &Self, info: proto::ParticipantInfo) -> ();
     );
 }
 
@@ -67,14 +70,10 @@ struct ParticipantInfo {
     pub connection_quality: ConnectionQuality,
 }
 
-#[derive(Default)]
-struct ParticipantEvents {}
-
 pub(super) struct ParticipantInternal {
     pub rtc_engine: Arc<RtcEngine>,
     pub info: RwLock<ParticipantInfo>,
     pub tracks: RwLock<HashMap<TrackSid, TrackPublication>>,
-    pub events: RwLock<ParticipantEvents>,
 }
 
 impl ParticipantInternal {
@@ -97,7 +96,6 @@ impl ParticipantInternal {
                 connection_quality: ConnectionQuality::Unknown,
             }),
             tracks: Default::default(),
-            events: Default::default(),
         }
     }
 
@@ -107,38 +105,6 @@ impl ParticipantInternal {
         info.name = new_info.name;
         info.identity = new_info.identity.into();
         info.metadata = new_info.metadata; // TODO(theomonnom): callback MetadataChanged
-    }
-
-    pub fn sid(&self) -> ParticipantSid {
-        self.info.read().sid.clone()
-    }
-
-    pub fn identity(&self) -> ParticipantIdentity {
-        self.info.read().identity.clone()
-    }
-
-    pub fn name(&self) -> String {
-        self.info.read().name.clone()
-    }
-
-    pub fn metadata(&self) -> String {
-        self.info.read().metadata.clone()
-    }
-
-    pub fn is_speaking(&self) -> bool {
-        self.info.read().speaking
-    }
-
-    pub fn tracks(&self) -> RwLockReadGuard<HashMap<TrackSid, TrackPublication>> {
-        self.tracks.read()
-    }
-
-    pub fn audio_level(&self) -> f32 {
-        self.info.read().audio_level
-    }
-
-    pub fn connection_quality(&self) -> ConnectionQuality {
-        self.info.read().connection_quality
     }
 
     pub fn set_speaking(&self, speaking: bool) {

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -57,8 +57,7 @@ impl Participant {
     );
 }
 
-#[derive(Debug)]
-pub(crate) struct ParticipantInfo {
+struct ParticipantInfo {
     pub sid: ParticipantSid,
     pub identity: ParticipantIdentity,
     pub name: String,
@@ -68,11 +67,14 @@ pub(crate) struct ParticipantInfo {
     pub connection_quality: ConnectionQuality,
 }
 
-#[derive(Debug)]
-pub(crate) struct ParticipantInternal {
-    pub(super) rtc_engine: Arc<RtcEngine>,
-    info: RwLock<ParticipantInfo>,
-    tracks: RwLock<HashMap<TrackSid, TrackPublication>>,
+#[derive(Default)]
+struct ParticipantEvents {}
+
+pub(super) struct ParticipantInternal {
+    pub rtc_engine: Arc<RtcEngine>,
+    pub info: RwLock<ParticipantInfo>,
+    pub tracks: RwLock<HashMap<TrackSid, TrackPublication>>,
+    pub events: RwLock<ParticipantEvents>,
 }
 
 impl ParticipantInternal {
@@ -95,6 +97,7 @@ impl ParticipantInternal {
                 connection_quality: ConnectionQuality::Unknown,
             }),
             tracks: Default::default(),
+            events: Default::default(),
         }
     }
 

--- a/livekit/src/room/participant/remote_participant.rs
+++ b/livekit/src/room/participant/remote_participant.rs
@@ -16,11 +16,11 @@ const ADD_TRACK_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Default)]
 struct RemoteEvents {
-    track_published: Option<Box<dyn Fn(RemoteTrackPublication)>>,
-    track_unpublished: Option<Box<dyn Fn(RemoteTrackPublication)>>,
-    track_subscribed: Option<Box<dyn Fn(RemoteTrack, RemoteTrackPublication)>>,
-    track_unsubscribed: Option<Box<dyn Fn(RemoteTrack, RemoteTrackPublication)>>,
-    track_subscription_failed: Option<Box<dyn Fn(TrackSid, TrackError)>>,
+    track_published: Option<Arc<dyn Fn(RemoteTrackPublication)>>,
+    track_unpublished: Option<Arc<dyn Fn(RemoteTrackPublication)>>,
+    track_subscribed: Option<Arc<dyn Fn(RemoteTrack, RemoteTrackPublication)>>,
+    track_unsubscribed: Option<Arc<dyn Fn(RemoteTrack, RemoteTrackPublication)>>,
+    track_subscription_failed: Option<Arc<dyn Fn(TrackSid, TrackError)>>,
 }
 
 struct RemoteInfo {

--- a/livekit/src/room/participant/remote_participant.rs
+++ b/livekit/src/room/participant/remote_participant.rs
@@ -111,7 +111,7 @@ impl RemoteParticipant {
 
             log::debug!("starting track: {:?}", sid);
 
-            remote_publication.update_track(Some(track.clone().into()));
+            remote_publication.set_track(Some(track.clone().into()));
             //track.set_muted(remote_publication.is_muted());
             track.update_info(proto::TrackInfo {
                 sid: remote_publication.sid().to_string(),
@@ -160,7 +160,7 @@ impl RemoteParticipant {
                 track_unpublished(publication.clone());
             }
 
-            publication.update_track(None);
+            publication.set_track(None);
         }
     }
 

--- a/livekit/src/room/publication/local.rs
+++ b/livekit/src/room/publication/local.rs
@@ -2,11 +2,22 @@ use super::TrackPublicationInner;
 use crate::participant::ParticipantInternal;
 use crate::prelude::*;
 use livekit_protocol as proto;
+use std::fmt::Debug;
 use std::sync::{Arc, Weak};
 
 #[derive(Clone)]
 pub struct LocalTrackPublication {
     inner: Arc<TrackPublicationInner>,
+}
+
+impl Debug for LocalTrackPublication {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalTrackPublication")
+            .field("sid", &self.sid())
+            .field("name", &self.name())
+            .field("kind", &self.kind())
+            .finish()
+    }
 }
 
 impl LocalTrackPublication {
@@ -24,83 +35,67 @@ impl LocalTrackPublication {
         }
     }
 
-    pub async fn mute(&self) {}
-
-    pub async fn unmute(&self) {}
-
-    pub async fn pause_upstream(&self) {}
-
-    pub async fn resume_upstream(&self) {}
-
-    /*pub fn set_muted(&self, muted: bool) {
-        if self.is_muted() == muted {
-            return;
-        }
-
-        self.track().rtc_track().set_enabled(!muted);
-
-        let participant = self.inner.publication_inner.participant().upgrade();
-        if participant.is_none() {
-            log::warn!("publication's participant is invalid, set_muted failed");
-            return;
-        }
-        let participant = participant.unwrap();
-
-        // Engine update muted
-
-        // Participant MUTED/UNMUTED event
-    }*/
-
-    pub fn sid(&self) -> TrackSid {
-        self.inner.publication_inner.sid()
+    pub(crate) fn on_muted(&self, f: impl Fn()) {
+        self.inner.events.write().muted = Some(Arc::new(f));
     }
 
-    pub fn name(&self) -> String {
-        self.inner.publication_inner.name()
-    }
-
-    pub fn kind(&self) -> TrackKind {
-        self.inner.publication_inner.kind()
-    }
-
-    pub fn source(&self) -> TrackSource {
-        self.inner.publication_inner.source()
-    }
-
-    pub fn simulcasted(&self) -> bool {
-        self.inner.publication_inner.simulcasted()
-    }
-
-    pub fn dimension(&self) -> TrackDimension {
-        self.inner.publication_inner.dimension()
-    }
-
-    pub fn track(&self) -> LocalTrack {
-        self.inner
-            .publication_inner
-            .track()
-            .unwrap()
-            .try_into()
-            .unwrap()
-    }
-
-    pub fn mime_type(&self) -> String {
-        self.inner.publication_inner.mime_type()
-    }
-
-    pub fn is_muted(&self) -> bool {
-        self.inner.publication_inner.is_muted()
-    }
-
-    pub fn is_remote(&self) -> bool {
-        false
+    pub(crate) fn on_unmuted(&self, f: impl Fn()) {
+        self.inner.events.write().unmuted = Some(Arc::new(f));
     }
 
     pub(crate) fn set_track(&self, track: Option<Track>) {
-        self.inner.update_track(track);
+        self.inner.set_track(track);
     }
 
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
         self.inner.update_info(info);
+    }
+
+    pub fn mute(&self) {
+        self.track().mute();
+    }
+
+    pub fn unmute(&self) {
+        self.track().unmute();
+    }
+
+    pub fn sid(&self) -> TrackSid {
+        self.inner.info.read().sid.clone()
+    }
+
+    pub fn name(&self) -> String {
+        self.inner.info.read().name.clone()
+    }
+
+    pub fn kind(&self) -> TrackKind {
+        self.inner.info.read().kind
+    }
+
+    pub fn source(&self) -> TrackSource {
+        self.inner.info.read().source
+    }
+
+    pub fn simulcasted(&self) -> bool {
+        self.inner.info.read().simulcasted
+    }
+
+    pub fn dimension(&self) -> TrackDimension {
+        self.inner.info.read().dimension
+    }
+
+    pub fn track(&self) -> LocalTrack {
+        self.inner.info.read().track.unwrap().try_into().unwrap()
+    }
+
+    pub fn mime_type(&self) -> String {
+        self.inner.info.read().mime_type.clone()
+    }
+
+    pub fn is_muted(&self) -> bool {
+        self.inner.info.read().muted
+    }
+
+    pub fn is_remote(&self) -> bool {
+        false
     }
 }

--- a/livekit/src/room/publication/local.rs
+++ b/livekit/src/room/publication/local.rs
@@ -35,12 +35,12 @@ impl LocalTrackPublication {
         }
     }
 
-    pub(crate) fn on_muted(&self, f: impl Fn()) {
-        self.inner.events.write().muted = Some(Arc::new(f));
+    pub(crate) fn on_muted(&self, f: impl Fn() + Send + 'static) {
+        *self.inner.events.muted.lock() = Some(Box::new(f));
     }
 
-    pub(crate) fn on_unmuted(&self, f: impl Fn()) {
-        self.inner.events.write().unmuted = Some(Arc::new(f));
+    pub(crate) fn on_unmuted(&self, f: impl Fn() + Send + 'static) {
+        *self.inner.events.unmuted.lock() = Some(Box::new(f));
     }
 
     pub(crate) fn set_track(&self, track: Option<Track>) {
@@ -84,7 +84,14 @@ impl LocalTrackPublication {
     }
 
     pub fn track(&self) -> LocalTrack {
-        self.inner.info.read().track.unwrap().try_into().unwrap()
+        self.inner
+            .info
+            .read()
+            .track
+            .clone()
+            .unwrap()
+            .try_into()
+            .unwrap()
     }
 
     pub fn mime_type(&self) -> String {

--- a/livekit/src/room/publication/local.rs
+++ b/livekit/src/room/publication/local.rs
@@ -1,18 +1,12 @@
 use super::TrackPublicationInner;
-use crate::id::TrackSid;
 use crate::participant::ParticipantInternal;
-use crate::track::{LocalTrack, TrackDimension, TrackKind, TrackSource};
+use crate::prelude::*;
 use livekit_protocol as proto;
 use std::sync::{Arc, Weak};
 
-#[derive(Debug)]
-struct LocalTrackPublicationInner {
-    publication_inner: TrackPublicationInner,
-}
-
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct LocalTrackPublication {
-    inner: Arc<LocalTrackPublicationInner>,
+    inner: Arc<TrackPublicationInner>,
 }
 
 impl LocalTrackPublication {
@@ -22,13 +16,11 @@ impl LocalTrackPublication {
         track: LocalTrack,
     ) -> Self {
         Self {
-            inner: Arc::new(LocalTrackPublicationInner {
-                publication_inner: TrackPublicationInner::new(
-                    info,
-                    participant,
-                    Some(track.into()),
-                ),
-            }),
+            inner: Arc::new(TrackPublicationInner::new(
+                info,
+                participant,
+                Some(track.into()),
+            )),
         }
     }
 
@@ -59,37 +51,30 @@ impl LocalTrackPublication {
         // Participant MUTED/UNMUTED event
     }*/
 
-    #[inline]
     pub fn sid(&self) -> TrackSid {
         self.inner.publication_inner.sid()
     }
 
-    #[inline]
     pub fn name(&self) -> String {
         self.inner.publication_inner.name()
     }
 
-    #[inline]
     pub fn kind(&self) -> TrackKind {
         self.inner.publication_inner.kind()
     }
 
-    #[inline]
     pub fn source(&self) -> TrackSource {
         self.inner.publication_inner.source()
     }
 
-    #[inline]
     pub fn simulcasted(&self) -> bool {
         self.inner.publication_inner.simulcasted()
     }
 
-    #[inline]
     pub fn dimension(&self) -> TrackDimension {
         self.inner.publication_inner.dimension()
     }
 
-    #[inline]
     pub fn track(&self) -> LocalTrack {
         self.inner
             .publication_inner
@@ -99,29 +84,23 @@ impl LocalTrackPublication {
             .unwrap()
     }
 
-    #[inline]
     pub fn mime_type(&self) -> String {
         self.inner.publication_inner.mime_type()
     }
 
-    #[inline]
     pub fn is_muted(&self) -> bool {
         self.inner.publication_inner.is_muted()
     }
 
-    #[inline]
     pub fn is_remote(&self) -> bool {
         false
     }
 
-    /*#[inline]
-    pub(crate) fn update_track(&self, track: Option<Track>) {
-        self.inner.publication_inner.update_track(track);
-    }*/
+    pub(crate) fn set_track(&self, track: Option<Track>) {
+        self.inner.update_track(track);
+    }
 
-    #[allow(dead_code)]
-    #[inline]
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
-        self.inner.publication_inner.update_info(info);
+        self.inner.update_info(info);
     }
 }

--- a/livekit/src/room/publication/mod.rs
+++ b/livekit/src/room/publication/mod.rs
@@ -45,6 +45,8 @@ impl TrackPublication {
         pub fn is_muted(self: &Self) -> bool;
         pub fn is_remote(self: &Self) -> bool;
 
+        pub(crate) fn on_muted(self: &Self, on_mute: impl Fn()) -> ();
+        pub(crate) fn on_unmuted(self: &Self, on_unmute: impl Fn()) -> ();
         pub(crate) fn set_track(self: &Self, track: Option<Track>) -> ();
         pub(crate) fn update_info(self: &Self, info: proto::TrackInfo) -> ();
     );
@@ -71,8 +73,8 @@ struct PublicationInfo {
 
 #[derive(Default)]
 struct PublicationEvents {
-    pub on_muted: Option<Arc<dyn Fn()>>,
-    pub on_unmuted: Option<Arc<dyn Fn()>>,
+    pub muted: Option<Arc<dyn Fn()>>,
+    pub unmuted: Option<Arc<dyn Fn()>>,
 }
 
 pub(super) struct TrackPublicationInner {
@@ -138,13 +140,13 @@ impl TrackPublicationInner {
 
             let events = self.events.clone();
             track.on_muted(move || {
-                if let Some(on_muted) = events.read().on_muted.clone() {
+                if let Some(on_muted) = events.read().muted.clone() {
                     on_muted();
                 }
             });
 
             track.on_unmuted(move || {
-                if let Some(on_unmuted) = events.read().on_unmuted.clone() {
+                if let Some(on_unmuted) = events.read().unmuted.clone() {
                     on_unmuted();
                 }
             });

--- a/livekit/src/room/publication/mod.rs
+++ b/livekit/src/room/publication/mod.rs
@@ -5,33 +5,13 @@ use crate::track::Track;
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use parking_lot::RwLock;
-use proto::observer::Dispatcher;
-use std::sync::Arc;
 use std::sync::Weak;
-use tokio::sync::Notify;
 
 mod local;
 mod remote;
 
 pub use local::*;
 pub use remote::*;
-
-#[derive(Debug, Clone)]
-pub enum PublicationEvent {
-    Muted,
-    Unmuted,
-    Subscribed,
-    Unsubscribed,
-    SubscriptionStatusChanged {
-        old_state: SubscriptionStatus,
-        new_state: SubscriptionStatus,
-    },
-    SubscriptionPermissionChanged {
-        old_state: PermissionStatus,
-        new_state: PermissionStatus,
-    },
-    SubscriptionFailed,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubscriptionStatus {
@@ -75,25 +55,22 @@ impl TrackPublication {
 }
 
 #[derive(Debug)]
-pub(crate) struct PublicationInfo {
-    track: Option<Track>,
-    name: String,
-    sid: TrackSid,
-    kind: TrackKind,
-    source: TrackSource,
-    simulcasted: bool,
-    dimension: TrackDimension,
-    mime_type: String,
-    muted: bool,
+pub(super) struct PublicationInfo {
+    pub track: Option<Track>,
+    pub name: String,
+    pub sid: TrackSid,
+    pub kind: TrackKind,
+    pub source: TrackSource,
+    pub simulcasted: bool,
+    pub dimension: TrackDimension,
+    pub mime_type: String,
+    pub muted: bool,
 }
 
 #[derive(Debug)]
-pub(crate) struct TrackPublicationInner {
-    info: RwLock<PublicationInfo>,
-    // dispatcher: Dispatcher<PublicationEvent>,
-    participant: Weak<ParticipantInternal>,
-    //forward_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
-    // forward_close: Arc<Notify>,
+pub(super) struct TrackPublicationInner {
+    pub info: RwLock<PublicationInfo>,
+    pub participant: Weak<ParticipantInternal>,
 }
 
 impl TrackPublicationInner {
@@ -122,70 +99,10 @@ impl TrackPublicationInner {
 
         Self {
             info: RwLock::new(info),
-            //dispatcher: Default::default(),
             participant,
-            //forward_handle: Default::default(),
-            //forward_close: Default::default(),
         }
     }
 
-    // Forward track events to the publication events
-    // e.g: this also allow us to access the signal_client and notify the server if
-    //  a local track changed mute state
-    /*async fn track_forward_task(
-        close_notifier: Weak<Notify>,
-        track: Track,
-        dispatcher: Dispatcher<PublicationEvent>,
-    ) {
-        let mut track_events = track.register_observer();
-        loop {
-            let notifier = close_notifier.upgrade();
-            if notifier.is_none() {
-                break;
-            }
-            let notified = notifier.as_ref().unwrap().notified();
-
-            tokio::select! {
-                _ = notified => {
-                    break;
-                }
-                Some(event) = track_events.recv() => {
-                    match event {
-                        TrackEvent::Muted => {
-                            dispatcher.dispatch(&PublicationEvent::Muted);
-                        }
-                        TrackEvent::Unmuted => {
-                            dispatcher.dispatch(&PublicationEvent::Unmuted);
-                        }
-                    }
-                }
-            }
-        }
-    }*/
-
-    pub fn update_track(&self, track: Option<Track>) {
-        //let forward_task = self.forward_handle.lock().take();
-        //if let Some(task) = forward_task {
-        // Make sure to close the old forwarder before changing the track
-        //self.forward_close.notify_waiters();
-        //let _ = task.await;
-        // }
-
-        let mut info = self.info.write();
-        info.track = track.clone();
-
-        if let Some(track) = track {
-            /*let _handle = tokio::spawn(Self::track_forward_task(
-                Arc::downgrade(&self.forward_close),
-                track,
-                self.dispatcher.clone(),
-            ));*/
-            //let mut forward_handle = self.forward_handle.lock();
-            //*forward_handle = Some(handle);
-        }
-    }
-
-    // Called when updating a participant info
     pub fn update_info(&self, new_info: proto::TrackInfo) {
         let mut info = self.info.write();
         info.name = new_info.name;
@@ -196,51 +113,19 @@ impl TrackPublicationInner {
             TrackKind::try_from(proto::TrackType::from_i32(new_info.r#type).unwrap()).unwrap();
         info.source = TrackSource::from(proto::TrackSource::from_i32(new_info.source).unwrap());
         info.simulcasted = new_info.simulcast;
-
-        // TODO MUTE ?????????????????
-        // info.muted = new_info.muted;
-        // if let Some(track) = info.track.as_ref() {
-        //    track.set_muted(info.muted);
-        // }
     }
 
-    pub fn participant(&self) -> Weak<ParticipantInternal> {
-        self.participant.clone()
-    }
+    pub fn set_track(&self, track: Option<Track>) {
+        let mut info = self.info.write();
+        if let Some(prev_track) = info.track {
+            // Unregister observer
+        }
 
-    pub fn sid(&self) -> TrackSid {
-        self.info.read().sid.clone()
-    }
+        info.track = track;
 
-    pub fn name(&self) -> String {
-        self.info.read().name.clone()
-    }
-
-    pub fn kind(&self) -> TrackKind {
-        self.info.read().kind
-    }
-
-    pub fn source(&self) -> TrackSource {
-        self.info.read().source
-    }
-
-    pub fn simulcasted(&self) -> bool {
-        self.info.read().simulcasted
-    }
-
-    pub fn dimension(&self) -> TrackDimension {
-        self.info.read().dimension.clone()
-    }
-
-    pub fn mime_type(&self) -> String {
-        self.info.read().mime_type.clone()
-    }
-
-    pub fn track(&self) -> Option<Track> {
-        self.info.read().track.clone()
-    }
-
-    pub fn is_muted(&self) -> bool {
-        self.info.read().muted
+        if let Some(track) = track {
+            info.sid = track.sid();
+            // Register observer
+        }
     }
 }

--- a/livekit/src/room/publication/mod.rs
+++ b/livekit/src/room/publication/mod.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 use crate::track::Track;
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use proto::observer::Dispatcher;
 use std::sync::Arc;
 use std::sync::Weak;
@@ -90,10 +90,10 @@ pub(crate) struct PublicationInfo {
 #[derive(Debug)]
 pub(crate) struct TrackPublicationInner {
     info: RwLock<PublicationInfo>,
-    dispatcher: Dispatcher<PublicationEvent>,
+    // dispatcher: Dispatcher<PublicationEvent>,
     participant: Weak<ParticipantInternal>,
     //forward_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
-    forward_close: Arc<Notify>,
+    // forward_close: Arc<Notify>,
 }
 
 impl TrackPublicationInner {
@@ -122,17 +122,17 @@ impl TrackPublicationInner {
 
         Self {
             info: RwLock::new(info),
-            dispatcher: Default::default(),
+            //dispatcher: Default::default(),
             participant,
             //forward_handle: Default::default(),
-            forward_close: Default::default(),
+            //forward_close: Default::default(),
         }
     }
 
     // Forward track events to the publication events
     // e.g: this also allow us to access the signal_client and notify the server if
     //  a local track changed mute state
-    async fn track_forward_task(
+    /*async fn track_forward_task(
         close_notifier: Weak<Notify>,
         track: Track,
         dispatcher: Dispatcher<PublicationEvent>,
@@ -161,13 +161,13 @@ impl TrackPublicationInner {
                 }
             }
         }
-    }
+    }*/
 
     pub fn update_track(&self, track: Option<Track>) {
         //let forward_task = self.forward_handle.lock().take();
         //if let Some(task) = forward_task {
         // Make sure to close the old forwarder before changing the track
-        self.forward_close.notify_waiters();
+        //self.forward_close.notify_waiters();
         //let _ = task.await;
         // }
 
@@ -175,11 +175,11 @@ impl TrackPublicationInner {
         info.track = track.clone();
 
         if let Some(track) = track {
-            let _handle = tokio::spawn(Self::track_forward_task(
+            /*let _handle = tokio::spawn(Self::track_forward_task(
                 Arc::downgrade(&self.forward_close),
                 track,
                 self.dispatcher.clone(),
-            ));
+            ));*/
             //let mut forward_handle = self.forward_handle.lock();
             //*forward_handle = Some(handle);
         }

--- a/livekit/src/room/publication/remote.rs
+++ b/livekit/src/room/publication/remote.rs
@@ -11,7 +11,6 @@ use std::sync::{Arc, Weak};
 struct RemoteInfo {
     subscribed: bool,
     allowed: bool,
-    // TODO(theomonnom): other remote info
 }
 
 #[derive(Debug)]

--- a/livekit/src/room/track/audio_track.rs
+++ b/livekit/src/room/track/audio_track.rs
@@ -1,3 +1,8 @@
+use super::track_dispatch;
+use crate::prelude::*;
+use livekit_protocol::enum_dispatch;
+use livekit_webrtc::prelude::*;
+
 #[derive(Clone, Debug)]
 pub enum AudioTrack {
     Local(LocalAudioTrack),
@@ -7,7 +12,6 @@ pub enum AudioTrack {
 impl AudioTrack {
     track_dispatch!([Local, Remote]);
 
-    #[inline]
     pub fn rtc_track(&self) -> RtcAudioTrack {
         match self {
             Self::Local(track) => track.rtc_track().into(),

--- a/livekit/src/room/track/audio_track.rs
+++ b/livekit/src/room/track/audio_track.rs
@@ -1,0 +1,38 @@
+#[derive(Clone, Debug)]
+pub enum AudioTrack {
+    Local(LocalAudioTrack),
+    Remote(RemoteAudioTrack),
+}
+
+impl AudioTrack {
+    track_dispatch!([Local, Remote]);
+
+    #[inline]
+    pub fn rtc_track(&self) -> RtcAudioTrack {
+        match self {
+            Self::Local(track) => track.rtc_track().into(),
+            Self::Remote(track) => track.rtc_track().into(),
+        }
+    }
+}
+
+impl From<AudioTrack> for Track {
+    fn from(track: AudioTrack) -> Self {
+        match track {
+            AudioTrack::Local(track) => Self::LocalAudio(track),
+            AudioTrack::Remote(track) => Self::RemoteAudio(track),
+        }
+    }
+}
+
+impl TryFrom<Track> for AudioTrack {
+    type Error = &'static str;
+
+    fn try_from(track: Track) -> Result<Self, Self::Error> {
+        match track {
+            Track::LocalAudio(track) => Ok(Self::Local(track)),
+            Track::RemoteAudio(track) => Ok(Self::Remote(track)),
+            _ => Err("not an audio track"),
+        }
+    }
+}

--- a/livekit/src/room/track/audio_track.rs
+++ b/livekit/src/room/track/audio_track.rs
@@ -1,5 +1,6 @@
 use super::track_dispatch;
 use crate::prelude::*;
+use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use livekit_webrtc::prelude::*;
 

--- a/livekit/src/room/track/local_audio_track.rs
+++ b/livekit/src/room/track/local_audio_track.rs
@@ -101,11 +101,6 @@ impl LocalAudioTrack {
     }
 
     #[inline]
-    pub fn register_observer(&self) -> mpsc::UnboundedReceiver<TrackEvent> {
-        self.inner.register_observer()
-    }
-
-    #[inline]
     pub fn is_remote(&self) -> bool {
         false
     }

--- a/livekit/src/room/track/local_audio_track.rs
+++ b/livekit/src/room/track/local_audio_track.rs
@@ -2,6 +2,7 @@ use super::TrackInner;
 use crate::prelude::*;
 use crate::rtc_engine::lk_runtime::LkRuntime;
 use core::panic;
+use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -105,15 +106,23 @@ impl LocalAudioTrack {
         false
     }
 
-    /*pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
-        self.inner.transceiver()
+    pub fn on_muted(&self, f: impl Fn()) {
+        self.inner.events.write().muted = Some(Arc::new(f));
     }
 
-    pub(crate) fn update_transceiver(&self, transceiver: Option<RtpTransceiver>) {
-        self.inner.update_transceiver(transceiver)
+    pub fn on_unmuted(&self, f: impl Fn()) {
+        self.inner.events.write().unmuted = Some(Arc::new(f));
+    }
+
+    pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
+        self.inner.info.read().transceiver.clone()
+    }
+
+    pub(crate) fn set_transceiver(&self, transceiver: Option<RtpTransceiver>) {
+        self.inner.info.write().transceiver = transceiver;
     }
 
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
         self.inner.update_info(info)
-    }*/
+    }
 }

--- a/livekit/src/room/track/local_audio_track.rs
+++ b/livekit/src/room/track/local_audio_track.rs
@@ -26,7 +26,7 @@ impl Debug for LocalAudioTrack {
 impl LocalAudioTrack {
     pub(crate) fn new(name: String, rtc_track: RtcAudioTrack, source: RtcAudioSource) -> Self {
         Self {
-            inner: Arc::new(TrackInner::new(
+            inner: Arc::new(super::new_inner(
                 "unknown".to_string().into(), // sid
                 name,
                 TrackKind::Audio,
@@ -84,11 +84,11 @@ impl LocalAudioTrack {
     }
 
     pub fn mute(&self) {
-        self.inner.set_muted(true);
+        super::set_muted(&self.inner, &Track::LocalAudio(self.clone()), true);
     }
 
     pub fn unmute(&self) {
-        self.inner.set_muted(false);
+        super::set_muted(&self.inner, &Track::LocalAudio(self.clone()), false);
     }
 
     pub fn rtc_track(&self) -> RtcAudioTrack {
@@ -106,11 +106,11 @@ impl LocalAudioTrack {
         false
     }
 
-    pub fn on_muted(&self, f: impl Fn() + Send + 'static) {
+    pub fn on_muted(&self, f: impl Fn(Track) + Send + 'static) {
         *self.inner.events.muted.lock() = Some(Box::new(f));
     }
 
-    pub fn on_unmuted(&self, f: impl Fn() + Send + 'static) {
+    pub fn on_unmuted(&self, f: impl Fn(Track) + Send + 'static) {
         *self.inner.events.unmuted.lock() = Some(Box::new(f));
     }
 
@@ -123,6 +123,6 @@ impl LocalAudioTrack {
     }
 
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
-        self.inner.update_info(info)
+        super::update_info(&self.inner, &Track::LocalAudio(self.clone()), info);
     }
 }

--- a/livekit/src/room/track/local_audio_track.rs
+++ b/livekit/src/room/track/local_audio_track.rs
@@ -52,7 +52,7 @@ impl LocalAudioTrack {
     }
 
     pub fn sid(&self) -> TrackSid {
-        self.inner.info.read().sid
+        self.inner.info.read().sid.clone()
     }
 
     pub fn name(&self) -> String {
@@ -92,7 +92,7 @@ impl LocalAudioTrack {
     }
 
     pub fn rtc_track(&self) -> RtcAudioTrack {
-        if let MediaStreamTrack::Audio(audio) = self.inner.rtc_track {
+        if let MediaStreamTrack::Audio(audio) = self.inner.rtc_track.clone() {
             return audio;
         }
         unreachable!();
@@ -106,12 +106,12 @@ impl LocalAudioTrack {
         false
     }
 
-    pub fn on_muted(&self, f: impl Fn()) {
-        self.inner.events.write().muted = Some(Arc::new(f));
+    pub fn on_muted(&self, f: impl Fn() + Send + 'static) {
+        *self.inner.events.muted.lock() = Some(Box::new(f));
     }
 
-    pub fn on_unmuted(&self, f: impl Fn()) {
-        self.inner.events.write().unmuted = Some(Arc::new(f));
+    pub fn on_unmuted(&self, f: impl Fn() + Send + 'static) {
+        *self.inner.events.unmuted.lock() = Some(Box::new(f));
     }
 
     pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {

--- a/livekit/src/room/track/local_audio_track.rs
+++ b/livekit/src/room/track/local_audio_track.rs
@@ -2,7 +2,6 @@ use super::TrackInner;
 use crate::prelude::*;
 use crate::rtc_engine::lk_runtime::LkRuntime;
 use core::panic;
-use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -51,86 +50,70 @@ impl LocalAudioTrack {
         Self::new(name.to_string(), rtc_track, source)
     }
 
-    #[inline]
     pub fn sid(&self) -> TrackSid {
-        self.inner.sid()
+        self.inner.info.read().sid
     }
 
-    #[inline]
     pub fn name(&self) -> String {
-        self.inner.name()
+        self.inner.info.read().name.clone()
     }
 
-    #[inline]
     pub fn kind(&self) -> TrackKind {
-        self.inner.kind()
+        self.inner.info.read().kind
     }
 
-    #[inline]
     pub fn source(&self) -> TrackSource {
-        self.inner.source()
+        self.inner.info.read().source
     }
 
-    #[inline]
     pub fn stream_state(&self) -> StreamState {
-        self.inner.stream_state()
+        self.inner.info.read().stream_state
     }
 
-    #[inline]
     pub fn enable(&self) {
-        self.inner.enable()
+        self.inner.rtc_track.set_enabled(true);
     }
 
-    #[inline]
     pub fn disable(&self) {
-        self.inner.disable()
+        self.inner.rtc_track.set_enabled(false);
     }
 
-    #[inline]
     pub fn is_muted(&self) -> bool {
-        self.inner.is_muted()
+        self.inner.info.read().muted
     }
 
-    #[inline]
     pub fn mute(&self) {
         self.inner.set_muted(true);
     }
 
-    #[inline]
     pub fn unmute(&self) {
         self.inner.set_muted(false);
     }
 
-    #[inline]
     pub fn rtc_track(&self) -> RtcAudioTrack {
-        if let MediaStreamTrack::Audio(audio) = self.inner.rtc_track() {
+        if let MediaStreamTrack::Audio(audio) = self.inner.rtc_track {
             return audio;
         }
-        unreachable!()
+        unreachable!();
     }
 
-    #[inline]
     pub fn rtc_source(&self) -> RtcAudioSource {
         self.source.clone()
     }
 
-    #[inline]
     pub fn is_remote(&self) -> bool {
         false
     }
 
-    #[inline]
-    pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
+    /*pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
         self.inner.transceiver()
     }
 
-    #[inline]
     pub(crate) fn update_transceiver(&self, transceiver: Option<RtpTransceiver>) {
         self.inner.update_transceiver(transceiver)
     }
 
-    #[inline]
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
         self.inner.update_info(info)
-    }
+    }*/
 }

--- a/livekit/src/room/track/local_track.rs
+++ b/livekit/src/room/track/local_track.rs
@@ -1,12 +1,8 @@
-use super::TrackInner;
 use super::{track_dispatch, LocalAudioTrack, LocalVideoTrack};
 use crate::prelude::*;
-use crate::track::TrackEvent;
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use livekit_webrtc::prelude::*;
-use std::sync::Arc;
-use tokio::sync::mpsc;
 
 #[derive(Clone, Debug)]
 pub enum LocalTrack {
@@ -28,6 +24,27 @@ impl LocalTrack {
         match self {
             Self::Audio(track) => track.rtc_track().into(),
             Self::Video(track) => track.rtc_track().into(),
+        }
+    }
+}
+
+impl From<LocalTrack> for Track {
+    fn from(track: LocalTrack) -> Self {
+        match track {
+            LocalTrack::Audio(track) => Self::LocalAudio(track),
+            LocalTrack::Video(track) => Self::LocalVideo(track),
+        }
+    }
+}
+
+impl TryFrom<Track> for LocalTrack {
+    type Error = &'static str;
+
+    fn try_from(track: Track) -> Result<Self, Self::Error> {
+        match track {
+            Track::LocalAudio(track) => Ok(Self::Audio(track)),
+            Track::LocalVideo(track) => Ok(Self::Video(track)),
+            _ => Err("not a local track"),
         }
     }
 }

--- a/livekit/src/room/track/local_track.rs
+++ b/livekit/src/room/track/local_track.rs
@@ -1,5 +1,6 @@
 use super::track_dispatch;
 use crate::prelude::*;
+use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use livekit_webrtc::prelude::*;
 

--- a/livekit/src/room/track/local_track.rs
+++ b/livekit/src/room/track/local_track.rs
@@ -1,6 +1,5 @@
-use super::{track_dispatch, LocalAudioTrack, LocalVideoTrack};
+use super::track_dispatch;
 use crate::prelude::*;
-use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use livekit_webrtc::prelude::*;
 
@@ -19,7 +18,6 @@ impl LocalTrack {
         pub fn unmute(self: &Self) -> ();
     );
 
-    #[inline]
     pub fn rtc_track(&self) -> MediaStreamTrack {
         match self {
             Self::Audio(track) => track.rtc_track().into(),

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -1,7 +1,6 @@
 use super::TrackInner;
 use crate::prelude::*;
 use crate::rtc_engine::lk_runtime::LkRuntime;
-use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -35,91 +34,6 @@ impl LocalVideoTrack {
         }
     }
 
-    #[inline]
-    pub fn sid(&self) -> TrackSid {
-        self.inner.sid()
-    }
-
-    #[inline]
-    pub fn name(&self) -> String {
-        self.inner.name()
-    }
-
-    #[inline]
-    pub fn kind(&self) -> TrackKind {
-        self.inner.kind()
-    }
-
-    #[inline]
-    pub fn source(&self) -> TrackSource {
-        self.inner.source()
-    }
-
-    #[inline]
-    pub fn stream_state(&self) -> StreamState {
-        self.inner.stream_state()
-    }
-
-    #[inline]
-    pub fn enable(&self) {
-        self.inner.enable()
-    }
-
-    #[inline]
-    pub fn disable(&self) {
-        self.inner.disable()
-    }
-
-    #[inline]
-    pub fn is_muted(&self) -> bool {
-        self.inner.is_muted()
-    }
-
-    #[inline]
-    pub fn mute(&self) {
-        self.inner.set_muted(true);
-    }
-
-    #[inline]
-    pub fn unmute(&self) {
-        self.inner.set_muted(false);
-    }
-
-    #[inline]
-    pub fn rtc_track(&self) -> RtcVideoTrack {
-        if let MediaStreamTrack::Video(video) = self.inner.rtc_track() {
-            return video;
-        }
-        unreachable!()
-    }
-
-    #[inline]
-    pub fn rtc_source(&self) -> RtcVideoSource {
-        self.source.clone()
-    }
-
-    #[inline]
-    pub fn is_remote(&self) -> bool {
-        false
-    }
-
-    #[inline]
-    pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
-        self.inner.transceiver()
-    }
-
-    #[inline]
-    pub(crate) fn update_transceiver(&self, transceiver: Option<RtpTransceiver>) {
-        self.inner.update_transceiver(transceiver)
-    }
-
-    #[inline]
-    pub(crate) fn update_info(&self, info: proto::TrackInfo) {
-        self.inner.update_info(info)
-    }
-}
-
-impl LocalVideoTrack {
     pub fn create_video_track(name: &str, source: RtcVideoSource) -> LocalVideoTrack {
         let rtc_track = match source.clone() {
             #[cfg(not(target_arch = "wasm32"))]
@@ -135,4 +49,70 @@ impl LocalVideoTrack {
 
         Self::new(name.to_string(), rtc_track, source)
     }
+
+    pub fn sid(&self) -> TrackSid {
+        self.inner.info.read().sid
+    }
+
+    pub fn name(&self) -> String {
+        self.inner.info.read().name.clone()
+    }
+
+    pub fn kind(&self) -> TrackKind {
+        self.inner.info.read().kind
+    }
+
+    pub fn source(&self) -> TrackSource {
+        self.inner.info.read().source
+    }
+
+    pub fn stream_state(&self) -> StreamState {
+        self.inner.info.read().stream_state
+    }
+
+    pub fn enable(&self) {
+        self.inner.rtc_track.set_enabled(true);
+    }
+
+    pub fn disable(&self) {
+        self.inner.rtc_track.set_enabled(false);
+    }
+
+    pub fn is_muted(&self) -> bool {
+        self.inner.info.read().muted
+    }
+
+    pub fn mute(&self) {
+        self.inner.set_muted(true);
+    }
+
+    pub fn unmute(&self) {
+        self.inner.set_muted(false);
+    }
+
+    pub fn rtc_track(&self) -> RtcVideoTrack {
+        if let MediaStreamTrack::Video(video) = self.inner.rtc_track {
+            return video;
+        }
+        unreachable!();
+    }
+
+    pub fn is_remote(&self) -> bool {
+        false
+    }
+
+    /*#[inline]
+    pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
+        self.inner.transceiver()
+    }
+
+    #[inline]
+    pub(crate) fn update_transceiver(&self, transceiver: Option<RtpTransceiver>) {
+        self.inner.update_transceiver(transceiver)
+    }
+
+    #[inline]
+    pub(crate) fn update_info(&self, info: proto::TrackInfo) {
+        self.inner.update_info(info)
+    }*/
 }

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -100,11 +100,6 @@ impl LocalVideoTrack {
     }
 
     #[inline]
-    pub fn register_observer(&self) -> mpsc::UnboundedReceiver<TrackEvent> {
-        self.inner.register_observer()
-    }
-
-    #[inline]
     pub fn is_remote(&self) -> bool {
         false
     }

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -25,7 +25,7 @@ impl Debug for LocalVideoTrack {
 impl LocalVideoTrack {
     pub fn new(name: String, rtc_track: RtcVideoTrack, source: RtcVideoSource) -> Self {
         Self {
-            inner: Arc::new(TrackInner::new(
+            inner: Arc::new(super::new_inner(
                 "unknown".to_string().into(), // sid
                 name,
                 TrackKind::Video,
@@ -84,11 +84,11 @@ impl LocalVideoTrack {
     }
 
     pub fn mute(&self) {
-        self.inner.set_muted(true);
+        super::set_muted(&self.inner, &Track::LocalVideo(self.clone()), true);
     }
 
     pub fn unmute(&self) {
-        self.inner.set_muted(false);
+        super::set_muted(&self.inner, &Track::LocalVideo(self.clone()), false);
     }
 
     pub fn rtc_track(&self) -> RtcVideoTrack {
@@ -106,11 +106,11 @@ impl LocalVideoTrack {
         self.source.clone()
     }
 
-    pub fn on_muted(&self, f: impl Fn() + Send + 'static) {
+    pub fn on_muted(&self, f: impl Fn(Track) + Send + 'static) {
         *self.inner.events.muted.lock() = Some(Box::new(f));
     }
 
-    pub fn on_unmuted(&self, f: impl Fn() + Send + 'static) {
+    pub fn on_unmuted(&self, f: impl Fn(Track) + Send + 'static) {
         *self.inner.events.unmuted.lock() = Some(Box::new(f));
     }
 
@@ -123,6 +123,6 @@ impl LocalVideoTrack {
     }
 
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
-        self.inner.update_info(info)
+        super::update_info(&self.inner, &&Track::LocalVideo(self.clone()), info);
     }
 }

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -5,7 +5,6 @@ use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 
 #[derive(Clone)]
 pub struct LocalVideoTrack {

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -1,6 +1,7 @@
 use super::TrackInner;
 use crate::prelude::*;
 use crate::rtc_engine::lk_runtime::LkRuntime;
+use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -101,18 +102,27 @@ impl LocalVideoTrack {
         false
     }
 
-    /*#[inline]
+    pub fn rtc_source(&self) -> RtcVideoSource {
+        self.source.clone()
+    }
+
+    pub fn on_muted(&self, f: impl Fn()) {
+        self.inner.events.write().muted = Some(Arc::new(f));
+    }
+
+    pub fn on_unmuted(&self, f: impl Fn()) {
+        self.inner.events.write().unmuted = Some(Arc::new(f));
+    }
+
     pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
-        self.inner.transceiver()
+        self.inner.info.read().transceiver.clone()
     }
 
-    #[inline]
-    pub(crate) fn update_transceiver(&self, transceiver: Option<RtpTransceiver>) {
-        self.inner.update_transceiver(transceiver)
+    pub(crate) fn set_transceiver(&self, transceiver: Option<RtpTransceiver>) {
+        self.inner.info.write().transceiver = transceiver;
     }
 
-    #[inline]
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
         self.inner.update_info(info)
-    }*/
+    }
 }

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -52,7 +52,7 @@ impl LocalVideoTrack {
     }
 
     pub fn sid(&self) -> TrackSid {
-        self.inner.info.read().sid
+        self.inner.info.read().sid.clone()
     }
 
     pub fn name(&self) -> String {
@@ -92,7 +92,7 @@ impl LocalVideoTrack {
     }
 
     pub fn rtc_track(&self) -> RtcVideoTrack {
-        if let MediaStreamTrack::Video(video) = self.inner.rtc_track {
+        if let MediaStreamTrack::Video(video) = self.inner.rtc_track.clone() {
             return video;
         }
         unreachable!();
@@ -106,12 +106,12 @@ impl LocalVideoTrack {
         self.source.clone()
     }
 
-    pub fn on_muted(&self, f: impl Fn()) {
-        self.inner.events.write().muted = Some(Arc::new(f));
+    pub fn on_muted(&self, f: impl Fn() + Send + 'static) {
+        *self.inner.events.muted.lock() = Some(Box::new(f));
     }
 
-    pub fn on_unmuted(&self, f: impl Fn()) {
-        self.inner.events.write().unmuted = Some(Arc::new(f));
+    pub fn on_unmuted(&self, f: impl Fn() + Send + 'static) {
+        *self.inner.events.unmuted.lock() = Some(Box::new(f));
     }
 
     pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -3,21 +3,26 @@ use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use livekit_webrtc::prelude::*;
 use parking_lot::RwLock;
+use std::{fmt::Debug, sync::Arc};
 use thiserror::Error;
 
+mod audio_track;
 mod local_audio_track;
 mod local_track;
 mod local_video_track;
 mod remote_audio_track;
 mod remote_track;
 mod remote_video_track;
+mod video_track;
 
+pub use audio_track::*;
 pub use local_audio_track::*;
 pub use local_track::*;
 pub use local_video_track::*;
 pub use remote_audio_track::*;
 pub use remote_track::*;
 pub use remote_video_track::*;
+pub use video_track::*;
 
 #[derive(Error, Debug, Clone)]
 pub enum TrackError {
@@ -46,34 +51,8 @@ pub enum TrackSource {
     ScreenshareAudio,
 }
 
-#[derive(Debug, Clone)]
-pub enum TrackEvent {
-    Muted,
-    Unmuted,
-}
-
 #[derive(Clone, Copy, Debug)]
 pub struct TrackDimension(pub u32, pub u32);
-
-#[derive(Clone, Debug)]
-pub enum Track {
-    LocalAudio(LocalAudioTrack),
-    LocalVideo(LocalVideoTrack),
-    RemoteAudio(RemoteAudioTrack),
-    RemoteVideo(RemoteVideoTrack),
-}
-
-#[derive(Clone, Debug)]
-pub enum VideoTrack {
-    Local(LocalVideoTrack),
-    Remote(RemoteVideoTrack),
-}
-
-#[derive(Clone, Debug)]
-pub enum AudioTrack {
-    Local(LocalAudioTrack),
-    Remote(RemoteAudioTrack),
-}
 
 macro_rules! track_dispatch {
     ([$($variant:ident),+]) => {
@@ -96,7 +75,13 @@ macro_rules! track_dispatch {
     };
 }
 
-pub(crate) use track_dispatch;
+#[derive(Clone, Debug)]
+pub enum Track {
+    LocalAudio(LocalAudioTrack),
+    LocalVideo(LocalVideoTrack),
+    RemoteAudio(RemoteAudioTrack),
+    RemoteVideo(RemoteVideoTrack),
+}
 
 impl Track {
     track_dispatch!([LocalAudio, LocalVideo, RemoteAudio, RemoteVideo]);
@@ -112,45 +97,29 @@ impl Track {
     }
 }
 
-impl VideoTrack {
-    track_dispatch!([Local, Remote]);
+pub(super) use track_dispatch;
 
-    #[inline]
-    pub fn rtc_track(&self) -> RtcVideoTrack {
-        match self {
-            Self::Local(track) => track.rtc_track(),
-            Self::Remote(track) => track.rtc_track(),
-        }
-    }
-}
-
-impl AudioTrack {
-    track_dispatch!([Local, Remote]);
-
-    #[inline]
-    pub fn rtc_track(&self) -> RtcAudioTrack {
-        match self {
-            Self::Local(track) => track.rtc_track().into(),
-            Self::Remote(track) => track.rtc_track().into(),
-        }
-    }
+#[derive(Default)]
+struct TrackEvents {
+    pub muted: Option<Arc<dyn Fn()>>,
+    pub unmuted: Option<Arc<dyn Fn()>>,
 }
 
 #[derive(Debug)]
 struct TrackInfo {
-    sid: TrackSid,
-    name: String,
-    kind: TrackKind,
-    source: TrackSource,
-    stream_state: StreamState,
-    muted: bool,
-    transceiver: Option<RtpTransceiver>,
+    pub sid: TrackSid,
+    pub name: String,
+    pub kind: TrackKind,
+    pub source: TrackSource,
+    pub stream_state: StreamState,
+    pub muted: bool,
+    pub transceiver: Option<RtpTransceiver>,
 }
 
-#[derive(Debug)]
-pub(crate) struct TrackInner {
-    info: RwLock<TrackInfo>,
-    rtc_track: MediaStreamTrack,
+pub(super) struct TrackInner {
+    pub info: RwLock<TrackInfo>,
+    pub rtc_track: MediaStreamTrack,
+    pub events: RwLock<TrackEvents>,
 }
 
 impl TrackInner {
@@ -166,70 +135,35 @@ impl TrackInner {
                 transceiver: None,
             }),
             rtc_track,
+            events: Default::default(),
         }
-    }
-
-    pub fn sid(&self) -> TrackSid {
-        self.info.read().sid.clone()
-    }
-
-    pub fn name(&self) -> String {
-        self.info.read().name.clone()
-    }
-
-    pub fn kind(&self) -> TrackKind {
-        self.info.read().kind
-    }
-
-    pub fn source(&self) -> TrackSource {
-        self.info.read().source
-    }
-
-    pub fn stream_state(&self) -> StreamState {
-        self.info.read().stream_state
-    }
-
-    pub fn is_muted(&self) -> bool {
-        self.info.read().muted
-    }
-
-    pub fn enable(&self) {
-        self.rtc_track.set_enabled(true);
-    }
-
-    pub fn disable(&self) {
-        self.rtc_track.set_enabled(false);
-    }
-
-    pub fn rtc_track(&self) -> MediaStreamTrack {
-        self.rtc_track.clone()
-    }
-
-    pub fn transceiver(&self) -> Option<RtpTransceiver> {
-        self.info.read().transceiver.clone()
-    }
-
-    pub fn update_transceiver(&self, transceiver: Option<RtpTransceiver>) {
-        self.info.write().transceiver = transceiver;
     }
 
     pub fn set_muted(&self, muted: bool) {
-        log::debug!("set_muted: {} {}", self.sid(), muted);
-        if self.is_muted() == muted {
+        let info = self.info.read();
+        log::debug!("set_muted: {} {}", info.sid, muted);
+        if info.muted == muted {
             return;
         }
+        drop(info);
 
         if muted {
-            self.disable();
+            self.rtc_track.set_enabled(false);
         } else {
-            self.enable();
+            self.rtc_track.set_enabled(true);
         }
 
-        self.dispatcher.dispatch(if muted {
-            &TrackEvent::Muted
+        self.info.write().muted = muted;
+
+        if muted {
+            if let Some(on_mute) = self.events.read().muted.clone() {
+                on_mute();
+            }
         } else {
-            &TrackEvent::Unmuted
-        });
+            if let Some(on_unmute) = self.events.read().unmuted.clone() {
+                on_unmute();
+            }
+        }
     }
 
     pub fn update_info(&self, new_info: proto::TrackInfo) {
@@ -239,99 +173,5 @@ impl TrackInner {
         info.kind =
             TrackKind::try_from(proto::TrackType::from_i32(new_info.r#type).unwrap()).unwrap();
         info.source = TrackSource::from(proto::TrackSource::from_i32(new_info.source).unwrap());
-        // Muted and StreamState are not handled separately (events)
-    }
-}
-
-impl From<RemoteTrack> for Track {
-    fn from(track: RemoteTrack) -> Self {
-        match track {
-            RemoteTrack::Audio(track) => Self::RemoteAudio(track),
-            RemoteTrack::Video(track) => Self::RemoteVideo(track),
-        }
-    }
-}
-
-impl From<LocalTrack> for Track {
-    fn from(track: LocalTrack) -> Self {
-        match track {
-            LocalTrack::Audio(track) => Self::LocalAudio(track),
-            LocalTrack::Video(track) => Self::LocalVideo(track),
-        }
-    }
-}
-
-impl From<VideoTrack> for Track {
-    fn from(track: VideoTrack) -> Self {
-        match track {
-            VideoTrack::Local(track) => Self::LocalVideo(track),
-            VideoTrack::Remote(track) => Self::RemoteVideo(track),
-        }
-    }
-}
-
-impl From<AudioTrack> for Track {
-    fn from(track: AudioTrack) -> Self {
-        match track {
-            AudioTrack::Local(track) => Self::LocalAudio(track),
-            AudioTrack::Remote(track) => Self::RemoteAudio(track),
-        }
-    }
-}
-
-impl TryFrom<Track> for RemoteTrack {
-    type Error = &'static str;
-
-    fn try_from(track: Track) -> Result<Self, Self::Error> {
-        match track {
-            Track::RemoteAudio(track) => Ok(Self::Audio(track)),
-            Track::RemoteVideo(track) => Ok(Self::Video(track)),
-            _ => Err("not a remote track"),
-        }
-    }
-}
-
-impl TryFrom<Track> for LocalTrack {
-    type Error = &'static str;
-
-    fn try_from(track: Track) -> Result<Self, Self::Error> {
-        match track {
-            Track::LocalAudio(track) => Ok(Self::Audio(track)),
-            Track::LocalVideo(track) => Ok(Self::Video(track)),
-            _ => Err("not a local track"),
-        }
-    }
-}
-
-impl TryFrom<Track> for VideoTrack {
-    type Error = &'static str;
-
-    fn try_from(track: Track) -> Result<Self, Self::Error> {
-        match track {
-            Track::LocalVideo(track) => Ok(Self::Local(track)),
-            Track::RemoteVideo(track) => Ok(Self::Remote(track)),
-            _ => Err("not a video track"),
-        }
-    }
-}
-
-impl TryFrom<Track> for AudioTrack {
-    type Error = &'static str;
-
-    fn try_from(track: Track) -> Result<Self, Self::Error> {
-        match track {
-            Track::LocalAudio(track) => Ok(Self::Local(track)),
-            Track::RemoteAudio(track) => Ok(Self::Remote(track)),
-            _ => Err("not an audio track"),
-        }
-    }
-}
-
-impl From<TrackKind> for MediaType {
-    fn from(kind: TrackKind) -> Self {
-        match kind {
-            TrackKind::Audio => Self::Audio,
-            TrackKind::Video => Self::Video,
-        }
     }
 }

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -51,7 +51,7 @@ pub enum TrackSource {
     ScreenshareAudio,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TrackDimension(pub u32, pub u32);
 
 macro_rules! track_dispatch {
@@ -68,9 +68,9 @@ macro_rules! track_dispatch {
             pub fn is_muted(self: &Self) -> bool;
             pub fn is_remote(self: &Self) -> bool;
 
-            pub(crate) fn transceiver(self: &Self) -> Option<RtpTransceiver>;
+            /*pub(crate) fn transceiver(self: &Self) -> Option<RtpTransceiver>;
             pub(crate) fn update_transceiver(self: &Self, transceiver: Option<RtpTransceiver>) -> ();
-            pub(crate) fn update_info(self: &Self, info: proto::TrackInfo) -> ();
+            pub(crate) fn update_info(self: &Self, info: proto::TrackInfo) -> ();*/
         );
     };
 }

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -1,11 +1,9 @@
 use crate::prelude::*;
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
-use livekit_protocol::observer::Dispatcher;
 use livekit_webrtc::prelude::*;
 use parking_lot::RwLock;
 use thiserror::Error;
-use tokio::sync::mpsc;
 
 mod local_audio_track;
 mod local_track;
@@ -90,7 +88,6 @@ macro_rules! track_dispatch {
             pub fn disable(self: &Self) -> ();
             pub fn is_muted(self: &Self) -> bool;
             pub fn is_remote(self: &Self) -> bool;
-            pub fn register_observer(self: &Self) -> mpsc::UnboundedReceiver<TrackEvent>;
 
             pub(crate) fn transceiver(self: &Self) -> Option<RtpTransceiver>;
             pub(crate) fn update_transceiver(self: &Self, transceiver: Option<RtpTransceiver>) -> ();
@@ -154,7 +151,6 @@ struct TrackInfo {
 pub(crate) struct TrackInner {
     info: RwLock<TrackInfo>,
     rtc_track: MediaStreamTrack,
-    dispatcher: Dispatcher<TrackEvent>,
 }
 
 impl TrackInner {
@@ -170,7 +166,6 @@ impl TrackInner {
                 transceiver: None,
             }),
             rtc_track,
-            dispatcher: Default::default(),
         }
     }
 
@@ -208,10 +203,6 @@ impl TrackInner {
 
     pub fn rtc_track(&self) -> MediaStreamTrack {
         self.rtc_track.clone()
-    }
-
-    pub fn register_observer(&self) -> mpsc::UnboundedReceiver<TrackEvent> {
-        self.dispatcher.register()
     }
 
     pub fn transceiver(&self) -> Option<RtpTransceiver> {

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -67,10 +67,12 @@ macro_rules! track_dispatch {
             pub fn disable(self: &Self) -> ();
             pub fn is_muted(self: &Self) -> bool;
             pub fn is_remote(self: &Self) -> bool;
+            pub fn on_muted(self: &Self, on_mute: impl Fn()) -> ();
+            pub fn on_unmuted(self: &Self, on_unmute: impl Fn()) -> ();
 
-            /*pub(crate) fn transceiver(self: &Self) -> Option<RtpTransceiver>;
-            pub(crate) fn update_transceiver(self: &Self, transceiver: Option<RtpTransceiver>) -> ();
-            pub(crate) fn update_info(self: &Self, info: proto::TrackInfo) -> ();*/
+            pub(crate) fn transceiver(self: &Self) -> Option<RtpTransceiver>;
+            pub(crate) fn set_transceiver(self: &Self, transceiver: Option<RtpTransceiver>) -> ();
+            pub(crate) fn update_info(self: &Self, info: proto::TrackInfo) -> ();
         );
     };
 }
@@ -86,7 +88,6 @@ pub enum Track {
 impl Track {
     track_dispatch!([LocalAudio, LocalVideo, RemoteAudio, RemoteVideo]);
 
-    #[inline]
     pub fn rtc_track(&self) -> MediaStreamTrack {
         match self {
             Self::LocalAudio(track) => track.rtc_track().into(),

--- a/livekit/src/room/track/remote_audio_track.rs
+++ b/livekit/src/room/track/remote_audio_track.rs
@@ -33,7 +33,7 @@ impl RemoteAudioTrack {
     }
 
     pub fn sid(&self) -> TrackSid {
-        self.inner.info.read().sid
+        self.inner.info.read().sid.clone()
     }
 
     pub fn name(&self) -> String {
@@ -65,7 +65,7 @@ impl RemoteAudioTrack {
     }
 
     pub fn rtc_track(&self) -> RtcAudioTrack {
-        if let MediaStreamTrack::Audio(audio) = self.inner.rtc_track {
+        if let MediaStreamTrack::Audio(audio) = self.inner.rtc_track.clone() {
             return audio;
         }
         unreachable!();
@@ -75,12 +75,12 @@ impl RemoteAudioTrack {
         true
     }
 
-    pub fn on_muted(&self, f: impl Fn()) {
-        self.inner.events.write().muted = Some(Arc::new(f));
+    pub fn on_muted(&self, f: impl Fn() + Send + 'static) {
+        *self.inner.events.muted.lock() = Some(Box::new(f));
     }
 
-    pub fn on_unmuted(&self, f: impl Fn()) {
-        self.inner.events.write().unmuted = Some(Arc::new(f));
+    pub fn on_unmuted(&self, f: impl Fn() + Send + 'static) {
+        *self.inner.events.unmuted.lock() = Some(Box::new(f));
     }
 
     pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {

--- a/livekit/src/room/track/remote_audio_track.rs
+++ b/livekit/src/room/track/remote_audio_track.rs
@@ -1,7 +1,5 @@
-use super::remote_track;
 use super::TrackInner;
 use crate::prelude::*;
-use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -33,73 +31,58 @@ impl RemoteAudioTrack {
         }
     }
 
-    #[inline]
     pub fn sid(&self) -> TrackSid {
-        self.inner.sid()
+        self.inner.info.read().sid
     }
 
-    #[inline]
     pub fn name(&self) -> String {
-        self.inner.name()
+        self.inner.info.read().name.clone()
     }
 
-    #[inline]
     pub fn kind(&self) -> TrackKind {
-        self.inner.kind()
+        self.inner.info.read().kind
     }
 
-    #[inline]
     pub fn source(&self) -> TrackSource {
-        self.inner.source()
+        self.inner.info.read().source
     }
 
-    #[inline]
     pub fn stream_state(&self) -> StreamState {
-        self.inner.stream_state()
+        self.inner.info.read().stream_state
     }
 
-    #[inline]
     pub fn enable(&self) {
-        self.inner.enable()
+        self.inner.rtc_track.set_enabled(true);
     }
 
-    #[inline]
     pub fn disable(&self) {
-        self.inner.disable()
+        self.inner.rtc_track.set_enabled(false);
     }
 
-    #[inline]
     pub fn is_muted(&self) -> bool {
-        self.inner.is_muted()
+        self.inner.info.read().muted
     }
 
-    #[inline]
     pub fn rtc_track(&self) -> RtcAudioTrack {
-        if let MediaStreamTrack::Audio(audio) = self.inner.rtc_track() {
+        if let MediaStreamTrack::Audio(audio) = self.inner.rtc_track {
             return audio;
         }
-        unreachable!()
+        unreachable!();
     }
 
-    #[inline]
     pub fn is_remote(&self) -> bool {
         true
     }
 
-    #[allow(dead_code)]
-    #[inline]
-    pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
+    /*pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
         self.inner.transceiver()
     }
 
-    #[inline]
-    #[allow(dead_code)]
     pub(crate) fn update_transceiver(&self, transceiver: Option<RtpTransceiver>) {
         self.inner.update_transceiver(transceiver)
     }
 
-    #[inline]
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
         remote_track::update_info(&self.inner, info);
-    }
+    }*/
 }

--- a/livekit/src/room/track/remote_audio_track.rs
+++ b/livekit/src/room/track/remote_audio_track.rs
@@ -5,7 +5,6 @@ use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 
 #[derive(Clone)]
 pub struct RemoteAudioTrack {
@@ -80,11 +79,6 @@ impl RemoteAudioTrack {
             return audio;
         }
         unreachable!()
-    }
-
-    #[inline]
-    pub fn register_observer(&self) -> mpsc::UnboundedReceiver<TrackEvent> {
-        self.inner.register_observer()
     }
 
     #[inline]

--- a/livekit/src/room/track/remote_audio_track.rs
+++ b/livekit/src/room/track/remote_audio_track.rs
@@ -1,5 +1,6 @@
 use super::TrackInner;
 use crate::prelude::*;
+use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -74,15 +75,23 @@ impl RemoteAudioTrack {
         true
     }
 
-    /*pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
-        self.inner.transceiver()
+    pub fn on_muted(&self, f: impl Fn()) {
+        self.inner.events.write().muted = Some(Arc::new(f));
     }
 
-    pub(crate) fn update_transceiver(&self, transceiver: Option<RtpTransceiver>) {
-        self.inner.update_transceiver(transceiver)
+    pub fn on_unmuted(&self, f: impl Fn()) {
+        self.inner.events.write().unmuted = Some(Arc::new(f));
+    }
+
+    pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
+        self.inner.info.read().transceiver.clone()
+    }
+
+    pub(crate) fn set_transceiver(&self, transceiver: Option<RtpTransceiver>) {
+        self.inner.info.write().transceiver = transceiver;
     }
 
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
-        remote_track::update_info(&self.inner, info);
-    }*/
+        self.inner.update_info(info)
+    }
 }

--- a/livekit/src/room/track/remote_audio_track.rs
+++ b/livekit/src/room/track/remote_audio_track.rs
@@ -1,4 +1,4 @@
-use super::TrackInner;
+use super::{remote_track, TrackInner};
 use crate::prelude::*;
 use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
@@ -23,7 +23,7 @@ impl Debug for RemoteAudioTrack {
 impl RemoteAudioTrack {
     pub(crate) fn new(sid: TrackSid, name: String, rtc_track: RtcAudioTrack) -> Self {
         Self {
-            inner: Arc::new(TrackInner::new(
+            inner: Arc::new(super::new_inner(
                 sid,
                 name,
                 TrackKind::Audio,
@@ -75,11 +75,11 @@ impl RemoteAudioTrack {
         true
     }
 
-    pub fn on_muted(&self, f: impl Fn() + Send + 'static) {
+    pub fn on_muted(&self, f: impl Fn(Track) + Send + 'static) {
         *self.inner.events.muted.lock() = Some(Box::new(f));
     }
 
-    pub fn on_unmuted(&self, f: impl Fn() + Send + 'static) {
+    pub fn on_unmuted(&self, f: impl Fn(Track) + Send + 'static) {
         *self.inner.events.unmuted.lock() = Some(Box::new(f));
     }
 
@@ -92,6 +92,6 @@ impl RemoteAudioTrack {
     }
 
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
-        self.inner.update_info(info)
+        remote_track::update_info(&self.inner, &Track::RemoteAudio(self.clone()), info);
     }
 }

--- a/livekit/src/room/track/remote_track.rs
+++ b/livekit/src/room/track/remote_track.rs
@@ -2,12 +2,10 @@ use super::track_dispatch;
 use super::TrackInner;
 use super::{RemoteAudioTrack, RemoteVideoTrack};
 use crate::prelude::*;
-use crate::track::TrackEvent;
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use livekit_webrtc::prelude::*;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 
 #[derive(Clone, Debug)]
 pub enum RemoteTrack {
@@ -30,4 +28,25 @@ impl RemoteTrack {
 pub(crate) fn update_info(track: &Arc<TrackInner>, new_info: proto::TrackInfo) {
     track.update_info(new_info.clone());
     track.set_muted(new_info.muted);
+}
+
+impl From<RemoteTrack> for Track {
+    fn from(track: RemoteTrack) -> Self {
+        match track {
+            RemoteTrack::Audio(track) => Self::RemoteAudio(track),
+            RemoteTrack::Video(track) => Self::RemoteVideo(track),
+        }
+    }
+}
+
+impl TryFrom<Track> for RemoteTrack {
+    type Error = &'static str;
+
+    fn try_from(track: Track) -> Result<Self, Self::Error> {
+        match track {
+            Track::RemoteAudio(track) => Ok(Self::Audio(track)),
+            Track::RemoteVideo(track) => Ok(Self::Video(track)),
+            _ => Err("not a remote track"),
+        }
+    }
 }

--- a/livekit/src/room/track/remote_track.rs
+++ b/livekit/src/room/track/remote_track.rs
@@ -1,6 +1,5 @@
 use super::track_dispatch;
 use super::TrackInner;
-use super::{RemoteAudioTrack, RemoteVideoTrack};
 use crate::prelude::*;
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
@@ -35,18 +34,6 @@ impl From<RemoteTrack> for Track {
         match track {
             RemoteTrack::Audio(track) => Self::RemoteAudio(track),
             RemoteTrack::Video(track) => Self::RemoteVideo(track),
-        }
-    }
-}
-
-impl TryFrom<Track> for RemoteTrack {
-    type Error = &'static str;
-
-    fn try_from(track: Track) -> Result<Self, Self::Error> {
-        match track {
-            Track::RemoteAudio(track) => Ok(Self::Audio(track)),
-            Track::RemoteVideo(track) => Ok(Self::Video(track)),
-            _ => Err("not a remote track"),
         }
     }
 }

--- a/livekit/src/room/track/remote_track.rs
+++ b/livekit/src/room/track/remote_track.rs
@@ -24,9 +24,9 @@ impl RemoteTrack {
     }
 }
 
-pub(crate) fn update_info(track: &Arc<TrackInner>, new_info: proto::TrackInfo) {
-    track.update_info(new_info.clone());
-    track.set_muted(new_info.muted);
+pub(super) fn update_info(inner: &Arc<TrackInner>, track: &Track, new_info: proto::TrackInfo) {
+    super::update_info(inner, track, new_info.clone());
+    super::set_muted(inner, track, new_info.muted);
 }
 
 impl From<RemoteTrack> for Track {

--- a/livekit/src/room/track/remote_track.rs
+++ b/livekit/src/room/track/remote_track.rs
@@ -37,3 +37,15 @@ impl From<RemoteTrack> for Track {
         }
     }
 }
+
+impl TryFrom<Track> for RemoteTrack {
+    type Error = &'static str;
+
+    fn try_from(track: Track) -> Result<Self, Self::Error> {
+        match track {
+            Track::RemoteAudio(track) => Ok(Self::Audio(track)),
+            Track::RemoteVideo(track) => Ok(Self::Video(track)),
+            _ => Err("not a local track"),
+        }
+    }
+}

--- a/livekit/src/room/track/remote_video_track.rs
+++ b/livekit/src/room/track/remote_video_track.rs
@@ -33,7 +33,7 @@ impl RemoteVideoTrack {
     }
 
     pub fn sid(&self) -> TrackSid {
-        self.inner.info.read().sid
+        self.inner.info.read().sid.clone()
     }
 
     pub fn name(&self) -> String {
@@ -65,7 +65,7 @@ impl RemoteVideoTrack {
     }
 
     pub fn rtc_track(&self) -> RtcVideoTrack {
-        if let MediaStreamTrack::Video(video) = self.inner.rtc_track {
+        if let MediaStreamTrack::Video(video) = self.inner.rtc_track.clone() {
             return video;
         }
         unreachable!();
@@ -75,12 +75,12 @@ impl RemoteVideoTrack {
         true
     }
 
-    pub fn on_muted(&self, f: impl Fn()) {
-        self.inner.events.write().muted = Some(Arc::new(f));
+    pub fn on_muted(&self, f: impl Fn() + Send + 'static) {
+        *self.inner.events.muted.lock() = Some(Box::new(f));
     }
 
-    pub fn on_unmuted(&self, f: impl Fn()) {
-        self.inner.events.write().unmuted = Some(Arc::new(f));
+    pub fn on_unmuted(&self, f: impl Fn() + Send + 'static) {
+        *self.inner.events.unmuted.lock() = Some(Box::new(f));
     }
 
     pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {

--- a/livekit/src/room/track/remote_video_track.rs
+++ b/livekit/src/room/track/remote_video_track.rs
@@ -1,12 +1,13 @@
 use super::TrackInner;
 use crate::prelude::*;
+use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct RemoteVideoTrack {
-    pub(crate) inner: Arc<TrackInner>,
+    inner: Arc<TrackInner>,
 }
 
 impl Debug for RemoteVideoTrack {
@@ -74,15 +75,23 @@ impl RemoteVideoTrack {
         true
     }
 
-    /*pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
-        self.inner.transceiver()
+    pub fn on_muted(&self, f: impl Fn()) {
+        self.inner.events.write().muted = Some(Arc::new(f));
     }
 
-    pub(crate) fn update_transceiver(&self, transceiver: Option<RtpTransceiver>) {
-        self.inner.update_transceiver(transceiver)
+    pub fn on_unmuted(&self, f: impl Fn()) {
+        self.inner.events.write().unmuted = Some(Arc::new(f));
+    }
+
+    pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
+        self.inner.info.read().transceiver.clone()
+    }
+
+    pub(crate) fn set_transceiver(&self, transceiver: Option<RtpTransceiver>) {
+        self.inner.info.write().transceiver = transceiver;
     }
 
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
-        remote_track::update_info(&self.inner, info);
-    }*/
+        self.inner.update_info(info)
+    }
 }

--- a/livekit/src/room/track/remote_video_track.rs
+++ b/livekit/src/room/track/remote_video_track.rs
@@ -1,6 +1,5 @@
-use super::{remote_track, TrackInner};
+use super::TrackInner;
 use crate::prelude::*;
-use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -32,73 +31,58 @@ impl RemoteVideoTrack {
         }
     }
 
-    #[inline]
     pub fn sid(&self) -> TrackSid {
-        self.inner.sid()
+        self.inner.info.read().sid
     }
 
-    #[inline]
     pub fn name(&self) -> String {
-        self.inner.name()
+        self.inner.info.read().name.clone()
     }
 
-    #[inline]
     pub fn kind(&self) -> TrackKind {
-        self.inner.kind()
+        self.inner.info.read().kind
     }
 
-    #[inline]
     pub fn source(&self) -> TrackSource {
-        self.inner.source()
+        self.inner.info.read().source
     }
 
-    #[inline]
     pub fn stream_state(&self) -> StreamState {
-        self.inner.stream_state()
+        self.inner.info.read().stream_state
     }
 
-    #[inline]
     pub fn enable(&self) {
-        self.inner.enable()
+        self.inner.rtc_track.set_enabled(true);
     }
 
-    #[inline]
     pub fn disable(&self) {
-        self.inner.disable()
+        self.inner.rtc_track.set_enabled(false);
     }
 
-    #[inline]
     pub fn is_muted(&self) -> bool {
-        self.inner.is_muted()
+        self.inner.info.read().muted
     }
 
-    #[inline]
     pub fn rtc_track(&self) -> RtcVideoTrack {
-        if let MediaStreamTrack::Video(video) = self.inner.rtc_track() {
+        if let MediaStreamTrack::Video(video) = self.inner.rtc_track {
             return video;
         }
-        unreachable!()
+        unreachable!();
     }
 
-    #[inline]
     pub fn is_remote(&self) -> bool {
         true
     }
 
-    #[allow(dead_code)]
-    #[inline]
-    pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
+    /*pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {
         self.inner.transceiver()
     }
 
-    #[allow(dead_code)]
-    #[inline]
     pub(crate) fn update_transceiver(&self, transceiver: Option<RtpTransceiver>) {
         self.inner.update_transceiver(transceiver)
     }
 
-    #[inline]
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
         remote_track::update_info(&self.inner, info);
-    }
+    }*/
 }

--- a/livekit/src/room/track/remote_video_track.rs
+++ b/livekit/src/room/track/remote_video_track.rs
@@ -4,7 +4,6 @@ use livekit_protocol as proto;
 use livekit_webrtc::prelude::*;
 use std::fmt::Debug;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 
 #[derive(Clone)]
 pub struct RemoteVideoTrack {

--- a/livekit/src/room/track/remote_video_track.rs
+++ b/livekit/src/room/track/remote_video_track.rs
@@ -82,11 +82,6 @@ impl RemoteVideoTrack {
     }
 
     #[inline]
-    pub fn register_observer(&self) -> mpsc::UnboundedReceiver<TrackEvent> {
-        self.inner.register_observer()
-    }
-
-    #[inline]
     pub fn is_remote(&self) -> bool {
         true
     }

--- a/livekit/src/room/track/remote_video_track.rs
+++ b/livekit/src/room/track/remote_video_track.rs
@@ -1,3 +1,4 @@
+use super::remote_track;
 use super::TrackInner;
 use crate::prelude::*;
 use livekit_protocol as proto;
@@ -23,7 +24,7 @@ impl Debug for RemoteVideoTrack {
 impl RemoteVideoTrack {
     pub(crate) fn new(sid: TrackSid, name: String, rtc_track: RtcVideoTrack) -> Self {
         Self {
-            inner: Arc::new(TrackInner::new(
+            inner: Arc::new(super::new_inner(
                 sid,
                 name,
                 TrackKind::Video,
@@ -75,11 +76,11 @@ impl RemoteVideoTrack {
         true
     }
 
-    pub fn on_muted(&self, f: impl Fn() + Send + 'static) {
+    pub fn on_muted(&self, f: impl Fn(Track) + Send + 'static) {
         *self.inner.events.muted.lock() = Some(Box::new(f));
     }
 
-    pub fn on_unmuted(&self, f: impl Fn() + Send + 'static) {
+    pub fn on_unmuted(&self, f: impl Fn(Track) + Send + 'static) {
         *self.inner.events.unmuted.lock() = Some(Box::new(f));
     }
 
@@ -92,6 +93,6 @@ impl RemoteVideoTrack {
     }
 
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
-        self.inner.update_info(info)
+        remote_track::update_info(&self.inner, &Track::RemoteVideo(self.clone()), info);
     }
 }

--- a/livekit/src/room/track/video_track.rs
+++ b/livekit/src/room/track/video_track.rs
@@ -1,0 +1,38 @@
+#[derive(Clone, Debug)]
+pub enum VideoTrack {
+    Local(LocalVideoTrack),
+    Remote(RemoteVideoTrack),
+}
+
+impl VideoTrack {
+    track_dispatch!([Local, Remote]);
+
+    #[inline]
+    pub fn rtc_track(&self) -> RtcVideoTrack {
+        match self {
+            Self::Local(track) => track.rtc_track(),
+            Self::Remote(track) => track.rtc_track(),
+        }
+    }
+}
+
+impl From<VideoTrack> for Track {
+    fn from(track: VideoTrack) -> Self {
+        match track {
+            VideoTrack::Local(track) => Self::LocalVideo(track),
+            VideoTrack::Remote(track) => Self::RemoteVideo(track),
+        }
+    }
+}
+
+impl TryFrom<Track> for VideoTrack {
+    type Error = &'static str;
+
+    fn try_from(track: Track) -> Result<Self, Self::Error> {
+        match track {
+            Track::LocalVideo(track) => Ok(Self::Local(track)),
+            Track::RemoteVideo(track) => Ok(Self::Remote(track)),
+            _ => Err("not a video track"),
+        }
+    }
+}

--- a/livekit/src/room/track/video_track.rs
+++ b/livekit/src/room/track/video_track.rs
@@ -1,3 +1,8 @@
+use super::track_dispatch;
+use crate::prelude::*;
+use livekit_protocol::enum_dispatch;
+use livekit_webrtc::prelude::*;
+
 #[derive(Clone, Debug)]
 pub enum VideoTrack {
     Local(LocalVideoTrack),

--- a/livekit/src/room/track/video_track.rs
+++ b/livekit/src/room/track/video_track.rs
@@ -1,5 +1,6 @@
 use super::track_dispatch;
 use crate::prelude::*;
+use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use livekit_webrtc::prelude::*;
 

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -654,7 +654,10 @@ impl SessionInner {
         if track.kind() == TrackKind::Video {
             let capabilities = LkRuntime::instance()
                 .pc_factory()
-                .get_rtp_sender_capabilities(track.kind().into());
+                .get_rtp_sender_capabilities(match track.kind() {
+                    TrackKind::Video => MediaType::Video,
+                    TrackKind::Audio => MediaType::Audio,
+                });
 
             let mut matched = Vec::new();
             let mut partial_matched = Vec::new();

--- a/livekit/src/signal_client/signal_stream.rs
+++ b/livekit/src/signal_client/signal_stream.rs
@@ -11,8 +11,6 @@ use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
-use super::SignalEvents;
-
 type WebSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 #[derive(Debug)]


### PR DESCRIPTION
We're currently using channels to send events to the users.
When using channels, the drawback is that states may have changed before user receive an event.
e.g (a track that is being unsubscribed quickly after subscription):

```rs
taska:
    room.tracks.insert(id, track);
    channel.send(RoomEvent::TrackSubscribed { track });

taskb:
    let track = room.tracks.remove(id);
    channel.send(RoomEvent::TrackUnsubscribed { track })

listen task:
    // 1. We first receive TrackSubscribed from the channel
    //   - But the track isn't inside room.tracks (because taskb was also already executed)
```

This is not necessarily an issue because you can use the states coming from the event: `event.track`
I'm just wondering if this could be a confusing part for the users. The solution is to simply replace the events channel with callbacks.

NOTE: The code in this PR is not using callbacks (yet, looking for feedbacks)

Also one advantage about using callbacks instead of channels is that it is easier to support participant & track events: We can ensure room events happen at the same times as participant/track events. Users will not need to spawn a new tokio task to start listening to these events.

FFI:
This drawback is not present when using the FFI (Even if we're using channel to forward events to the main thread because we're reconstructing every state)