### PR TITLE
feat: warn blocking callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,10 +44,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "async-trait"
+version = "0.1.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -63,6 +119,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -182,6 +244,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4cf42660ac07fcebed809cfe561dd8730bcd35b075215e6479c516bcd0d11cb"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "parking_lot",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +318,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -576,6 +685,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +796,18 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -817,7 +951,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64",
+ "base64 0.21.2",
  "ring",
  "serde",
  "serde_json",
@@ -892,6 +1026,7 @@ dependencies = [
 name = "livekit-ffi"
 version = "0.1.3"
 dependencies = [
+ "console-subscriber",
  "dashmap",
  "env_logger",
  "futures-util",
@@ -956,6 +1091,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1116,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1012,6 +1168,25 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1159,6 +1334,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,8 +1483,23 @@ checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1303,7 +1513,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1405,7 +1615,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -1417,6 +1627,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
 
 [[package]]
 name = "ryu"
@@ -1553,6 +1769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "tempfile"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1906,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,7 +1962,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1752,6 +2004,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1788,6 +2051,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.2",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,7 +2118,19 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1811,6 +2140,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1896,6 +2242,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/livekit-ffi/Cargo.toml
+++ b/livekit-ffi/Cargo.toml
@@ -14,10 +14,13 @@ rustls-tls-native-roots = ["livekit/rustls-tls-native-roots"]
 rustls-tls-webpki-roots = ["livekit/rustls-tls-webpki-roots"]
 __rustls-tls = ["livekit/__rustls-tls"]
 
+# Enable tokio-console to debug tasks
+tracing = ["tokio/tracing", "console-subscriber"]
+
 [dependencies]
 livekit = { path = "../livekit", version = "0.1.3" }
 livekit-protocol = { path = "../livekit-protocol", version = "0.1.3" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.0", features = ["full", "parking_lot"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
 prost = "0.11.0"
@@ -27,6 +30,7 @@ thiserror = "1.0.38"
 log = "0.4.17"
 dashmap = "5.4.0"
 env_logger = "0.10.0"
+console-subscriber = { version = "0.1.10", features = ["parking_lot"], optional = true }
 
 [build-dependencies]
 webrtc-sys-build = { path = "../webrtc-sys/build", version = "0.1.3" }

--- a/livekit-ffi/src/lib.rs
+++ b/livekit-ffi/src/lib.rs
@@ -40,7 +40,7 @@ pub extern "C" fn livekit_ffi_request(
     let res = match proto::FfiRequest::decode(data) {
         Ok(res) => res,
         Err(err) => {
-            eprintln!("failed to decode request: {}", err);
+            log::error!("failed to decode request: {}", err);
             return INVALID_HANDLE;
         }
     };
@@ -48,7 +48,7 @@ pub extern "C" fn livekit_ffi_request(
     let res = match server::FFI_SERVER.handle_request(res) {
         Ok(res) => res,
         Err(err) => {
-            eprintln!("failed to handle request: {}", err);
+            log::error!("failed to handle request: {}", err);
             return INVALID_HANDLE;
         }
     }

--- a/livekit-ffi/src/server/audio_frame.rs
+++ b/livekit-ffi/src/server/audio_frame.rs
@@ -21,7 +21,7 @@ impl FfiAudioSream {
     /// Setup a new AudioStream and forward the audio data to the client/the foreign
     /// language.
     ///
-    /// When FFIAudioStream is dropped (When the corresponding handle_id is dropped), the task
+    /// When FfiAudioStream is dropped (When the corresponding handle_id is dropped), the task
     /// is being closed.
     ///
     /// It is possible that the client receives an AudioFrame after the task is closed. The client
@@ -121,7 +121,7 @@ impl FfiAudioSream {
                                 },
                             )),
                         },
-                    )) {
+                    )).await {
                         warn!("failed to send audio frame: {}", err);
                     }
                 }

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -12,7 +12,6 @@ use std::slice;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::oneshot;
 
 pub mod audio_frame;
 pub mod room;

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -135,7 +135,6 @@ impl FfiServer {
         let _ = self
             .async_runtime
             .spawn_blocking(move || unsafe {
-                std::thread::sleep(Duration::from_secs(5));
                 callback_fn(message.as_ptr(), message.len());
                 let _ = tx.send(());
             })

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -11,6 +11,8 @@ use prost::Message;
 use std::slice;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::oneshot;
 
 pub mod audio_frame;
 pub mod room;
@@ -41,11 +43,13 @@ impl Default for FfiServer {
     fn default() -> Self {
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
+        #[cfg(feature = "tracing")]
+        console_subscriber::init();
+
         // Create a background thread which checks for deadlocks every 10s
         {
             use parking_lot::deadlock;
             use std::thread;
-            use std::time::Duration;
 
             thread::spawn(move || loop {
                 thread::sleep(Duration::from_secs(10));
@@ -105,7 +109,7 @@ impl FfiServer {
         self.next_id.fetch_add(1, Ordering::Relaxed)
     }
 
-    pub fn send_event(&'static self, message: proto::ffi_event::Message) -> FfiResult<()> {
+    pub async fn send_event(&'static self, message: proto::ffi_event::Message) -> FfiResult<()> {
         let callback_fn = self
             .config
             .lock()
@@ -117,9 +121,26 @@ impl FfiServer {
         }
         .encode_to_vec();
 
-        unsafe {
-            callback_fn(message.as_ptr(), message.len());
-        }
+        let (tx, rx) = oneshot::channel();
+
+        self.async_runtime.spawn(async move {
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(2)) => {
+                    log::error!("sending an event to the foreign language took too much time, is your callback function blocking?");
+                }
+                _ = rx => {}
+            }
+        });
+
+        let _ = self
+            .async_runtime
+            .spawn_blocking(move || unsafe {
+                std::thread::sleep(Duration::from_secs(5));
+                callback_fn(message.as_ptr(), message.len());
+                let _ = tx.send(());
+            })
+            .await;
+
         Ok(())
     }
 }
@@ -173,26 +194,24 @@ impl FfiServer {
         self.async_runtime.spawn(async move {
             // Try to connect to the Room
             let res = room::FfiRoom::connect(&self, connect).await;
-
-            // match res
             match res {
                 Ok(room_info) => {
-                    let _ = self.send_event(proto::ffi_event::Message::Connect(
-                        proto::ConnectCallback {
+                    let _ = self
+                        .send_event(proto::ffi_event::Message::Connect(proto::ConnectCallback {
                             async_id: Some(async_id.into()),
                             error: None,
                             room: Some(room_info),
-                        },
-                    ));
+                        }))
+                        .await;
                 }
                 Err(err) => {
-                    let _ = self.send_event(proto::ffi_event::Message::Connect(
-                        proto::ConnectCallback {
+                    let _ = self
+                        .send_event(proto::ffi_event::Message::Connect(proto::ConnectCallback {
                             async_id: Some(async_id.into()),
                             error: Some(err.to_string()),
                             room: None,
-                        },
-                    ));
+                        }))
+                        .await;
                 }
             }
         });
@@ -216,24 +235,29 @@ impl FfiServer {
             .id as FfiHandleId;
 
         self.async_runtime.spawn(async move {
-            let mut ffi_room = self
-                .ffi_handles
-                .get_mut(&room_handle)
-                .ok_or(FfiError::InvalidRequest("room not found"))
-                .unwrap();
+            let ffi_room = {
+                let mut ffi_room = self
+                    .ffi_handles
+                    .get_mut(&room_handle)
+                    .ok_or(FfiError::InvalidRequest("room not found"))
+                    .unwrap();
 
-            let ffi_room = ffi_room
-                .value_mut()
-                .downcast_mut::<room::HandleType>()
-                .ok_or(FfiError::InvalidRequest("room is not a FfiRoom"))
-                .unwrap();
+                ffi_room
+                    .value_mut()
+                    .downcast_mut::<room::HandleType>()
+                    .ok_or(FfiError::InvalidRequest("room is not a FfiRoom"))
+                    .unwrap()
+                    .clone()
+            };
 
             ffi_room.close().await;
-            let _ = self.send_event(proto::ffi_event::Message::Disconnect(
-                proto::DisconnectCallback {
-                    async_id: Some(async_id.into()),
-                },
-            ));
+            let _ = self
+                .send_event(proto::ffi_event::Message::Disconnect(
+                    proto::DisconnectCallback {
+                        async_id: Some(async_id.into()),
+                    },
+                ))
+                .await;
         });
 
         Ok(proto::DisconnectResponse {
@@ -254,14 +278,17 @@ impl FfiServer {
                     .ok_or(FfiError::InvalidRequest("room_handle is empty"))?
                     .id as FfiHandleId;
 
-                let ffi_room = self
-                    .ffi_handles
-                    .get(&room_handle)
-                    .ok_or(FfiError::InvalidRequest("room not found"))?;
+                let ffi_room = {
+                    let ffi_room = self
+                        .ffi_handles
+                        .get(&room_handle)
+                        .ok_or(FfiError::InvalidRequest("room not found"))?;
 
-                let ffi_room = ffi_room
-                    .downcast_ref::<room::HandleType>()
-                    .ok_or(FfiError::InvalidRequest("room is not a FfiRoom"))?;
+                    ffi_room
+                        .downcast_ref::<room::HandleType>()
+                        .ok_or(FfiError::InvalidRequest("room is not a FfiRoom"))?
+                        .clone()
+                };
 
                 let track_handle = publish
                     .track_handle
@@ -269,16 +296,19 @@ impl FfiServer {
                     .ok_or(FfiError::InvalidRequest("track_handle is empty"))?
                     .id as FfiHandleId;
 
-                let track = self
-                    .ffi_handles
-                    .get(&track_handle)
-                    .ok_or(FfiError::InvalidRequest("track not found"))?;
+                let track = {
+                    let track = self
+                        .ffi_handles
+                        .get(&track_handle)
+                        .ok_or(FfiError::InvalidRequest("track not found"))?;
 
-                let track = track
-                    .downcast_ref::<Track>()
-                    .ok_or(FfiError::InvalidRequest("track is not a Track"))?;
+                    track
+                        .downcast_ref::<Track>()
+                        .ok_or(FfiError::InvalidRequest("track is not a Track"))?
+                        .clone()
+                };
 
-                let local_track = LocalTrack::try_from(track.clone())
+                let local_track = LocalTrack::try_from(track)
                     .map_err(|_| FfiError::InvalidRequest("track is not a LocalTrack"))?;
 
                 let publication = ffi_room
@@ -294,13 +324,16 @@ impl FfiServer {
             }
             .await;
 
-            if let Err(err) = self.send_event(proto::ffi_event::Message::PublishTrack(
-                proto::PublishTrackCallback {
-                    async_id: Some(async_id.into()),
-                    error: res.as_ref().err().map(|e| e.to_string()),
-                    publication: res.as_ref().ok().map(Into::into),
-                },
-            )) {
+            if let Err(err) = self
+                .send_event(proto::ffi_event::Message::PublishTrack(
+                    proto::PublishTrackCallback {
+                        async_id: Some(async_id.into()),
+                        error: res.as_ref().err().map(|e| e.to_string()),
+                        publication: res.as_ref().ok().map(Into::into),
+                    },
+                ))
+                .await
+            {
                 log::warn!("error sending PublishTrack callback: {}", err);
             }
         });

--- a/livekit-ffi/src/server/video_frame.rs
+++ b/livekit-ffi/src/server/video_frame.rs
@@ -123,7 +123,7 @@ impl FfiVideoStream {
                                 }
                             )),
                         }
-                    )) {
+                    )).await{
                         warn!("failed to send video frame: {}", err);
                     }
                 }

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -513,6 +513,7 @@ impl SessionInner {
                         let _ = self.emitter.send(SessionEvent::Connected);
                     }
                 } else if state == PeerConnectionState::Failed {
+                    log::error!("{:?} pc state failed", target);
                     self.pc_state
                         .store(PeerState::Disconnected as u8, Ordering::SeqCst);
 


### PR DESCRIPTION
- reduce lock times with scopes on some requests
- support tokio-console for tasks debugging on the ffi with the `tracing` feature flag 

This will print an error on the console if we detect a blocking callback. (Default to 2s)