### PR TITLE
feat: use libwebrtc m114

### DIFF
--- a/livekit-webrtc/src/native/rtp_parameters.rs
+++ b/livekit-webrtc/src/native/rtp_parameters.rs
@@ -270,15 +270,7 @@ impl From<RtpCodecCapability> for sys_rp::ffi::RtpCodecCapability {
             mime_type: String::default(), // !!
             has_preferred_payload_type: false,
             preferred_payload_type: 0,
-            has_max_ptime: false,
-            max_ptime: 0,
-            has_ptime: false,
-            ptime: 0,
             rtcp_feedback: Vec::default(),
-            options: Vec::default(),
-            max_temporal_layer_extensions: 0,
-            max_spatial_layer_extensions: 0,
-            svc_multi_stream_support: false,
         }
     }
 }

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -104,6 +104,7 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=gdi32");
             println!("cargo:rustc-link-lib=dylib=dxgi");
             println!("cargo:rustc-link-lib=dylib=dwmapi");
+            println!("cargo:rustc-link-lib=dylib=shcore");
 
             builder.flag("/std:c++20").flag("/EHsc");
         }

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -105,7 +105,7 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=dxgi");
             println!("cargo:rustc-link-lib=dylib=dwmapi");
 
-            builder.flag("/std:c++17").flag("/EHsc");
+            builder.flag("/std:c++20").flag("/EHsc");
         }
         "linux" => {
             println!("cargo:rustc-link-lib=dylib=Xext");
@@ -116,7 +116,7 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=pthread");
             println!("cargo:rustc-link-lib=dylib=m");
 
-            builder.flag("-std=c++17");
+            builder.flag("-std=c++20");
         }
         "macos" => {
             println!("cargo:rustc-link-lib=framework=Foundation");
@@ -139,7 +139,7 @@ fn main() {
             builder
                 .file("src/objc_video_factory.mm")
                 .flag("-stdlib=libc++")
-                .flag("-std=c++17");
+                .flag("-std=c++20");
         }
         "ios" => {
             println!("cargo:rustc-link-lib=framework=CoreFoundation");
@@ -159,7 +159,7 @@ fn main() {
 
             configure_darwin_sysroot(&mut builder);
 
-            builder.file("src/objc_video_factory.mm").flag("-std=c++17");
+            builder.file("src/objc_video_factory.mm").flag("-std=c++20");
         }
         "android" => {
             webrtc_sys_build::configure_jni_symbols().unwrap();
@@ -172,7 +172,7 @@ fn main() {
 
             builder
                 .file("src/android.cpp")
-                .flag("-std=c++17")
+                .flag("-std=c++20")
                 .cpp_link_stdlib("c++_static");
         }
         _ => {

--- a/webrtc-sys/build/src/lib.rs
+++ b/webrtc-sys/build/src/lib.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 use reqwest::StatusCode;
 
 pub const SCRATH_PATH: &str = "livekit_webrtc";
-pub const WEBRTC_TAG: &str = "webrtc-4a9b827";
+pub const WEBRTC_TAG: &str = "webrtc-d5ec6fa";
 pub const IGNORE_DEFINES: [&str; 2] = ["CR_CLANG_REVISION", "CR_XCODE_VERSION"];
 
 pub fn target_os() -> String {

--- a/webrtc-sys/include/livekit/rtp_transceiver.h
+++ b/webrtc-sys/include/livekit/rtp_transceiver.h
@@ -69,11 +69,12 @@ class RtpTransceiver {
 
   rust::Vec<RtpCodecCapability> codec_preferences() const;
 
-  rust::Vec<RtpHeaderExtensionCapability> header_extensions_to_offer() const;
+  rust::Vec<RtpHeaderExtensionCapability> header_extensions_to_negotiate()
+      const;
 
-  rust::Vec<RtpHeaderExtensionCapability> header_extensions_negotiated() const;
+  rust::Vec<RtpHeaderExtensionCapability> negotiated_header_extensions() const;
 
-  void set_offered_rtp_header_extensions(
+  void set_header_extensions_to_negotiate(
       rust::Vec<RtpHeaderExtensionCapability> header_extensions_to_offer) const;
 
  private:

--- a/webrtc-sys/include/livekit/video_frame.h
+++ b/webrtc-sys/include/livekit/video_frame.h
@@ -38,7 +38,6 @@ class VideoFrame {
   uint16_t id() const;
   int64_t timestamp_us() const;
   int64_t ntp_time_ms() const;
-  uint32_t transport_frame_id() const;
   uint32_t timestamp() const;
 
   VideoRotation rotation() const;

--- a/webrtc-sys/src/rtp_parameters.cpp
+++ b/webrtc-sys/src/rtp_parameters.cpp
@@ -42,12 +42,6 @@ webrtc::RtpCodecCapability to_native_rtp_codec_capability(
   if (capability.has_preferred_payload_type)
     native.preferred_payload_type = capability.preferred_payload_type;
 
-  if (capability.has_max_ptime)
-    native.max_ptime = capability.max_ptime;
-
-  if (capability.has_ptime)
-    native.ptime = capability.ptime;
-
   if (capability.has_num_channels)
     native.num_channels = capability.num_channels;
 
@@ -56,14 +50,6 @@ webrtc::RtpCodecCapability to_native_rtp_codec_capability(
 
   for (auto pair : capability.parameters)
     native.parameters.insert(std::pair(pair.key, pair.value));
-
-  for (auto pair : capability.options)
-    native.options.insert(std::pair(pair.key, pair.value));
-
-  native.max_temporal_layer_extensions =
-      capability.max_temporal_layer_extensions;
-  native.max_spatial_layer_extensions = capability.max_spatial_layer_extensions;
-  native.svc_multi_stream_support = capability.svc_multi_stream_support;
 
   return native;
 }
@@ -159,12 +145,6 @@ webrtc::RtpCodecParameters to_native_rtp_codec_parameters(
   if (params.has_num_channels)
     native.num_channels = params.num_channels;
 
-  if (params.has_ptime)
-    native.ptime = params.ptime;
-
-  if (params.has_max_ptime)
-    native.max_ptime = params.max_ptime;
-
   if (params.has_clock_rate)
     native.clock_rate = params.clock_rate;
 
@@ -250,16 +230,6 @@ RtpCodecCapability to_rust_rtp_codec_capability(
     rust.preferred_payload_type = capability.preferred_payload_type.value();
   }
 
-  if (capability.max_ptime.has_value()) {
-    rust.has_max_ptime = true;
-    rust.max_ptime = capability.max_ptime.value();
-  }
-
-  if (capability.ptime.has_value()) {
-    rust.has_ptime = true;
-    rust.ptime = capability.ptime.value();
-  }
-
   if (capability.num_channels) {
     rust.has_num_channels = true;
     rust.num_channels = capability.num_channels.value();
@@ -271,12 +241,6 @@ RtpCodecCapability to_rust_rtp_codec_capability(
   for (auto param : capability.parameters)
     rust.parameters.push_back(StringKeyValue{param.first, param.second});
 
-  for (auto option : capability.options)
-    rust.options.push_back(StringKeyValue{option.first, option.second});
-
-  rust.max_temporal_layer_extensions = capability.max_temporal_layer_extensions;
-  rust.max_spatial_layer_extensions = capability.max_spatial_layer_extensions;
-  rust.svc_multi_stream_support = capability.svc_multi_stream_support;
   return rust;
 }
 
@@ -383,16 +347,6 @@ RtpCodecParameters to_rust_rtp_codec_parameters(
   if (params.num_channels.has_value()) {
     rust.has_num_channels = true;
     rust.num_channels = params.num_channels.value();
-  }
-
-  if (params.max_ptime.has_value()) {
-    rust.has_max_ptime = true;
-    rust.max_ptime = params.max_ptime.value();
-  }
-
-  if (params.ptime.has_value()) {
-    rust.has_ptime = true;
-    rust.ptime = params.ptime.value();
   }
 
   for (auto feedback : params.rtcp_feedback)

--- a/webrtc-sys/src/rtp_parameters.rs
+++ b/webrtc-sys/src/rtp_parameters.rs
@@ -61,18 +61,10 @@ pub mod ffi {
         pub clock_rate: i32,
         pub has_preferred_payload_type: bool,
         pub preferred_payload_type: i32,
-        pub has_max_ptime: bool,
-        pub max_ptime: i32,
-        pub has_ptime: bool,
-        pub ptime: i32,
         pub has_num_channels: bool,
         pub num_channels: i32,
         pub rtcp_feedback: Vec<RtcpFeedback>,
         pub parameters: Vec<StringKeyValue>,
-        pub options: Vec<StringKeyValue>,
-        pub max_temporal_layer_extensions: i32,
-        pub max_spatial_layer_extensions: i32,
-        pub svc_multi_stream_support: bool,
     }
 
     #[derive(Debug)]

--- a/webrtc-sys/src/rtp_transceiver.cpp
+++ b/webrtc-sys/src/rtp_transceiver.cpp
@@ -114,31 +114,31 @@ rust::Vec<RtpCodecCapability> RtpTransceiver::codec_preferences() const {
 }
 
 rust::Vec<RtpHeaderExtensionCapability>
-RtpTransceiver::header_extensions_to_offer() const {
+RtpTransceiver::header_extensions_to_negotiate() const {
   rust::Vec<RtpHeaderExtensionCapability> rust;
-  for (auto header : transceiver_->HeaderExtensionsToOffer())
+  for (auto header : transceiver_->GetHeaderExtensionsToNegotiate())
     rust.push_back(to_rust_rtp_header_extension_capability(header));
 
   return rust;
 }
 
 rust::Vec<RtpHeaderExtensionCapability>
-RtpTransceiver::header_extensions_negotiated() const {
+RtpTransceiver::negotiated_header_extensions() const {
   rust::Vec<RtpHeaderExtensionCapability> rust;
-  for (auto header : transceiver_->HeaderExtensionsNegotiated())
+  for (auto header : transceiver_->GetNegotiatedHeaderExtensions())
     rust.push_back(to_rust_rtp_header_extension_capability(header));
 
   return rust;
 }
 
-void RtpTransceiver::set_offered_rtp_header_extensions(
+void RtpTransceiver::set_header_extensions_to_negotiate(
     rust::Vec<RtpHeaderExtensionCapability> header_extensions_to_offer) const {
   std::vector<webrtc::RtpHeaderExtensionCapability> headers;
 
   for (auto header : header_extensions_to_offer)
     headers.push_back(to_native_rtp_header_extension_capability(header));
 
-  auto error = transceiver_->SetOfferedRtpHeaderExtensions(headers);
+  auto error = transceiver_->SetHeaderExtensionsToNegotiate(headers);
   if (!error.ok())
     throw std::runtime_error(serialize_error(to_error(error)));
 }

--- a/webrtc-sys/src/rtp_transceiver.rs
+++ b/webrtc-sys/src/rtp_transceiver.rs
@@ -48,10 +48,12 @@ pub mod ffi {
             codecs: Vec<RtpCodecCapability>,
         ) -> Result<()>;
         fn codec_preferences(self: &RtpTransceiver) -> Vec<RtpCodecCapability>;
-        fn header_extensions_to_offer(self: &RtpTransceiver) -> Vec<RtpHeaderExtensionCapability>;
-        fn header_extensions_negotiated(self: &RtpTransceiver)
+        fn header_extensions_to_negotiate(
+            self: &RtpTransceiver,
+        ) -> Vec<RtpHeaderExtensionCapability>;
+        fn negotiated_header_extensions(self: &RtpTransceiver)
             -> Vec<RtpHeaderExtensionCapability>;
-        fn set_offered_rtp_header_extensions(
+        fn set_header_extensions_to_negotiate(
             self: &RtpTransceiver,
             headers: Vec<RtpHeaderExtensionCapability>,
         ) -> Result<()>;

--- a/webrtc-sys/src/video_decoder_factory.cpp
+++ b/webrtc-sys/src/video_decoder_factory.cpp
@@ -16,11 +16,11 @@
 
 #include "livekit/video_decoder_factory.h"
 
-#include "api/video_codecs/builtin_video_decoder_factory.h"
-#include "api/video_codecs/builtin_video_encoder_factory.h"
 #include "api/video_codecs/sdp_video_format.h"
 #include "livekit/objc_video_factory.h"
 #include "media/base/media_constants.h"
+#include "modules/video_coding/codecs/h264/include/h264.h"
+#include "modules/video_coding/codecs/vp8/include/vp8.h"
 #include "rtc_base/logging.h"
 
 #ifdef WEBRTC_ANDROID
@@ -30,8 +30,6 @@
 namespace livekit {
 
 VideoDecoderFactory::VideoDecoderFactory() {
-  factories_.push_back(webrtc::CreateBuiltinVideoDecoderFactory());
-
 #ifdef __APPLE__
   factories_.push_back(livekit::CreateObjCVideoDecoderFactory());
 #endif
@@ -46,11 +44,18 @@ VideoDecoderFactory::VideoDecoderFactory() {
 std::vector<webrtc::SdpVideoFormat> VideoDecoderFactory::GetSupportedFormats()
     const {
   std::vector<webrtc::SdpVideoFormat> formats;
+
   for (const auto& factory : factories_) {
     auto supported_formats = factory->GetSupportedFormats();
     formats.insert(formats.end(), supported_formats.begin(),
                    supported_formats.end());
   }
+
+  formats.push_back(webrtc::SdpVideoFormat(cricket::kVp8CodecName));
+  for (const webrtc::SdpVideoFormat& h264_format :
+       webrtc::SupportedH264DecoderCodecs())
+    formats.push_back(h264_format);
+
   return formats;
 }
 
@@ -62,6 +67,11 @@ std::unique_ptr<webrtc::VideoDecoder> VideoDecoderFactory::CreateVideoDecoder(
         return factory->CreateVideoDecoder(format);
     }
   }
+
+  if (absl::EqualsIgnoreCase(format.name, cricket::kVp8CodecName))
+    return webrtc::VP8Decoder::Create();
+  if (absl::EqualsIgnoreCase(format.name, cricket::kH264CodecName))
+    return webrtc::H264Decoder::Create();
 
   RTC_LOG(LS_ERROR) << "No VideoDecoder found for " << format.name;
   return nullptr;

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -38,7 +38,7 @@ using Factory =
     webrtc::VideoEncoderFactoryTemplate<webrtc::LibvpxVp8EncoderTemplateAdapter
 #if defined(WEBRTC_USE_H264)
                                         ,
-                                        webrtc::OpenH264EncoderTemplateAdapter,
+                                        webrtc::OpenH264EncoderTemplateAdapter
 #endif
                                         >;
 

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -30,12 +30,13 @@
 
 namespace livekit {
 
-using Factory = webrtc::VideoEncoderFactoryTemplate<
-    webrtc::LibvpxVp8EncoderTemplateAdapter
+using Factory =
+    webrtc::VideoEncoderFactoryTemplate<webrtc::LibvpxVp8EncoderTemplateAdapter
 #if defined(WEBRTC_USE_H264)
-        webrtc::OpenH264EncoderTemplateAdapter,
+                                        ,
+                                        webrtc::OpenH264EncoderTemplateAdapter,
 #endif
-    >;
+                                        >;
 
 VideoEncoderFactory::VideoEncoderFactory() {
 #ifdef __APPLE__

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -24,6 +24,10 @@
 #include "media/base/media_constants.h"
 #include "rtc_base/logging.h"
 
+#if defined(WEBRTC_USE_H264)
+#include "api/video_codecs/video_encoder_factory_template_open_h264_adapter.h"
+#endif
+
 #ifdef WEBRTC_ANDROID
 #include "livekit/android.h"
 #endif

--- a/webrtc-sys/src/video_frame.cpp
+++ b/webrtc-sys/src/video_frame.cpp
@@ -42,9 +42,6 @@ int64_t VideoFrame::timestamp_us() const {
 int64_t VideoFrame::ntp_time_ms() const {
   return frame_.ntp_time_ms();
 }
-uint32_t VideoFrame::transport_frame_id() const {
-  return frame_.transport_frame_id();
-}
 uint32_t VideoFrame::timestamp() const {
   return frame_.timestamp();
 }

--- a/webrtc-sys/src/video_frame.rs
+++ b/webrtc-sys/src/video_frame.rs
@@ -28,7 +28,6 @@ pub mod ffi {
         fn id(self: &VideoFrame) -> u16;
         fn timestamp_us(self: &VideoFrame) -> i64;
         fn ntp_time_ms(self: &VideoFrame) -> i64;
-        fn transport_frame_id(self: &VideoFrame) -> u32;
         fn timestamp(self: &VideoFrame) -> u32;
         fn rotation(self: &VideoFrame) -> VideoRotation;
         unsafe fn video_frame_buffer(self: &VideoFrame) -> UniquePtr<VideoFrameBuffer>;


### PR DESCRIPTION
- use libwebrtc m114

enabled codecs atm: vp8 & h264



NOTE: This PR uses c++20 to fix some issues on Windows (The webrtc code use c++20 features like designated initializers).
For now the libwebrtc build scripts use c++17 for compiling, we will definitely need to change the scripts to use c++20 in the future. (see #129)