### PR TITLE
fix: undefined symbols for simulcast adapter

### DIFF
--- a/webrtc-sys/libwebrtc/build_android.sh
+++ b/webrtc-sys/libwebrtc/build_android.sh
@@ -55,6 +55,7 @@ fi
 cd src
 # git apply "$COMMAND_DIR/patches/add_licenses.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 git apply "$COMMAND_DIR/patches/ssl_verify_callback_with_native_handle.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+git apply "$COMMAND_DIR/patches/add_deps.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 git apply "$COMMAND_DIR/patches/android_use_libunwind.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 cd ..
 
@@ -97,9 +98,7 @@ gn gen "$OUTPUT_DIR" --root="src" --args="${args}"
 ninja -C "$OUTPUT_DIR" :default \
   sdk/android:native_api \
   sdk/android:libwebrtc \
-  sdk/android:libjingle_peerconnection_so \
-  builtin_video_decoder_factory \
-  builtin_video_encoder_factory
+  sdk/android:libjingle_peerconnection_so
 
 # make libwebrtc.a
 # don't include nasm

--- a/webrtc-sys/libwebrtc/build_ios.sh
+++ b/webrtc-sys/libwebrtc/build_ios.sh
@@ -66,6 +66,7 @@ fi
 cd src
 # git apply "$COMMAND_DIR/patches/add_licenses.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 git apply "$COMMAND_DIR/patches/ssl_verify_callback_with_native_handle.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+git apply "$COMMAND_DIR/patches/add_deps.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 cd ..
 
 mkdir -p "$ARTIFACTS_DIR/lib"
@@ -108,9 +109,7 @@ ninja -C "$OUTPUT_DIR" :default \
   sdk:default_codec_factory_objc \
   pc:peerconnection \
   sdk:videocapture_objc \
-  sdk:framework_objc \
-  builtin_video_decoder_factory \
-  builtin_video_encoder_factory
+  sdk:framework_objc
 
 # make libwebrtc.a
 # don't include nasm

--- a/webrtc-sys/libwebrtc/build_linux.sh
+++ b/webrtc-sys/libwebrtc/build_linux.sh
@@ -55,6 +55,7 @@ fi
 cd src
 git apply "$COMMAND_DIR/patches/add_licenses.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 git apply "$COMMAND_DIR/patches/ssl_verify_callback_with_native_handle.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+git apply "$COMMAND_DIR/patches/add_deps.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 cd ..
 
 mkdir -p "$ARTIFACTS_DIR/lib"
@@ -95,9 +96,7 @@ fi
 gn gen "$OUTPUT_DIR" --root="src" --args="${args}"
 
 # build static library
-ninja -C "$OUTPUT_DIR" :default \
-  builtin_video_decoder_factory \
-  builtin_video_encoder_factory
+ninja -C "$OUTPUT_DIR" :default
 
 # make libwebrtc.a
 # don't include nasm

--- a/webrtc-sys/libwebrtc/build_macos.sh
+++ b/webrtc-sys/libwebrtc/build_macos.sh
@@ -55,6 +55,7 @@ fi
 cd src
 git apply "$COMMAND_DIR/patches/add_licenses.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 git apply "$COMMAND_DIR/patches/ssl_verify_callback_with_native_handle.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+git apply "$COMMAND_DIR/patches/add_deps.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 cd ..
 
 mkdir -p "$ARTIFACTS_DIR/lib"
@@ -96,9 +97,7 @@ ninja -C "$OUTPUT_DIR" :default \
   sdk:default_codec_factory_objc \
   pc:peerconnection \
   sdk:videocapture_objc \
-  sdk:mac_framework_objc \
-  builtin_video_decoder_factory \
-  builtin_video_encoder_factory
+  sdk:mac_framework_objc
 
 # make libwebrtc.a
 # don't include nasm

--- a/webrtc-sys/libwebrtc/build_windows.cmd
+++ b/webrtc-sys/libwebrtc/build_windows.cmd
@@ -51,6 +51,7 @@ if not exist src (
 
 cd src
 call git apply "%COMMAND_DIR%/patches/add_licenses.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+call git apply "%COMMAND_DIR%/patches/add_deps.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 call git apply "%COMMAND_DIR%/patches/ssl_verify_callback_with_native_handle.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 cd ..
 
@@ -66,7 +67,7 @@ call gn.bat gen %OUTPUT_DIR% --root="src" ^
   --args="is_debug=!debug! is_clang=true target_cpu=\"!arch!\" use_custom_libcxx=false rtc_include_tests=false rtc_build_examples=false rtc_build_tools=false is_component_build=false rtc_enable_protobuf=false rtc_use_h264=true symbol_level=0 enable_iterator_debugging=false use_cxx17=true"
 
 rem build
-ninja.exe -C %OUTPUT_DIR% :default builtin_video_decoder_factory builtin_video_encoder_factory
+ninja.exe -C %OUTPUT_DIR% :default
 
 rem copy static library for release build
 copy "%OUTPUT_DIR%\obj\webrtc.lib" "%ARTIFACTS_DIR%\lib"

--- a/webrtc-sys/libwebrtc/patches/add_deps.patch
+++ b/webrtc-sys/libwebrtc/patches/add_deps.patch
@@ -1,0 +1,14 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index d5289b8..12685d1 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -517,6 +517,9 @@ if (!build_with_chromium) {
+       "pc:rtc_pc",
+       "sdk",
+       "video",
++      "//third_party/zlib",
++      "rtc_base:log_sinks",
++      "media:rtc_simulcast_encoder_adapter",
+     ]
+ 
+     if (rtc_include_builtin_audio_codecs) {


### PR DESCRIPTION
I initially decided to go with:
`call lib.exe /OUT:"%ARTIFACTS_DIR%\lib\webrtc.lib" %OUTPUT_DIR%\obj\webrtc.lib %OUTPUT_DIR%\obj\media\rtc_simulcast_encoder_adapter\simulcast_encoder_adapter.obj`

but decided to pick a cleaner patch from https://github.com/shiguredo-webrtc-build/webrtc-build/blob/master/patches/add_deps.patch

my previous [commit](https://github.com/livekit/client-sdk-rust/commit/6f5b45690efc7bbdba4d1ae973f67ff17fcbafa8) was not sufficient

