### PR TITLE
feat: sync states after resume 

### DIFF
--- a/livekit-webrtc/src/data_channel.rs
+++ b/livekit-webrtc/src/data_channel.rs
@@ -77,6 +77,10 @@ impl DataChannel {
         self.handle.send(data, binary)
     }
 
+    pub fn id(&self) -> i32 {
+        self.handle.id()
+    }
+
     pub fn label(&self) -> String {
         self.handle.label()
     }

--- a/livekit-webrtc/src/native/data_channel.rs
+++ b/livekit-webrtc/src/native/data_channel.rs
@@ -87,6 +87,10 @@ impl DataChannel {
             .ok_or(DataChannelError::Send)
     }
 
+    pub fn id(&self) -> i32 {
+        self.sys_handle.id()
+    }
+
     pub fn label(&self) -> String {
         self.sys_handle.label()
     }

--- a/livekit/src/room/publication/local.rs
+++ b/livekit/src/room/publication/local.rs
@@ -52,17 +52,25 @@ impl LocalTrackPublication {
         super::set_track(&self.inner, &TrackPublication::Local(self.clone()), track);
     }
 
+    pub(crate) fn proto_info(&self) -> proto::TrackInfo {
+        self.inner.info.read().proto_info.clone()
+    }
+
     #[allow(dead_code)]
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
         super::update_info(&self.inner, &TrackPublication::Local(self.clone()), info);
     }
 
     pub fn mute(&self) {
-        self.track().mute();
+        if let Some(track) = self.track() {
+            track.mute();
+        }
     }
 
     pub fn unmute(&self) {
-        self.track().unmute();
+        if let Some(track) = self.track() {
+            track.unmute();
+        }
     }
 
     pub fn sid(&self) -> TrackSid {
@@ -89,15 +97,13 @@ impl LocalTrackPublication {
         self.inner.info.read().dimension
     }
 
-    pub fn track(&self) -> LocalTrack {
+    pub fn track(&self) -> Option<LocalTrack> {
         self.inner
             .info
             .read()
             .track
             .clone()
-            .unwrap()
-            .try_into()
-            .unwrap()
+            .map(|track| track.try_into().unwrap())
     }
 
     pub fn mime_type(&self) -> String {

--- a/livekit/src/room/publication/remote.rs
+++ b/livekit/src/room/publication/remote.rs
@@ -135,6 +135,11 @@ impl RemoteTrackPublication {
         }
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn proto_info(&self) -> proto::TrackInfo {
+        self.inner.info.read().proto_info.clone()
+    }
+
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
         super::update_info(
             &self.inner,
@@ -241,7 +246,11 @@ impl RemoteTrackPublication {
     }
 
     pub fn is_subscribed(&self) -> bool {
-        self.is_allowed() && self.track().is_some()
+        self.track().is_some() && self.remote.info.read().subscribed
+    }
+
+    pub fn is_desired(&self) -> bool {
+        self.remote.info.read().subscribed
     }
 
     pub fn is_allowed(&self) -> bool {

--- a/webrtc-sys/include/livekit/data_channel.h
+++ b/webrtc-sys/include/livekit/data_channel.h
@@ -45,6 +45,7 @@ class DataChannel {
   void register_observer(rust::Box<DataChannelObserverWrapper> observer) const;
   void unregister_observer() const;
   bool send(const DataBuffer& buffer) const;
+  int id() const;
   rust::String label() const;
   DataState state() const;
   void close() const;

--- a/webrtc-sys/src/data_channel.cpp
+++ b/webrtc-sys/src/data_channel.cpp
@@ -76,6 +76,10 @@ bool DataChannel::send(const DataBuffer& buffer) const {
       rtc::CopyOnWriteBuffer(buffer.ptr, buffer.len), buffer.binary});
 }
 
+int DataChannel::id() const {
+  return data_channel_->id();
+}
+
 rust::String DataChannel::label() const {
   return data_channel_->label();
 }

--- a/webrtc-sys/src/data_channel.rs
+++ b/webrtc-sys/src/data_channel.rs
@@ -65,6 +65,7 @@ pub mod ffi {
         fn unregister_observer(self: &DataChannel);
 
         fn send(self: &DataChannel, data: &DataBuffer) -> bool;
+        fn id(self: &DataChannel) -> i32;
         fn label(self: &DataChannel) -> String;
         fn state(self: &DataChannel) -> DataState;
         fn close(self: &DataChannel);


### PR DESCRIPTION
- correctly sync states after signal resume
- now using a "`LastInfo`" struct to store the last successful session states
- also fixed `LocalTrackPublication::track` returning `LocalTrack` instead of `Option<LocalTrack>`
   - It was a wrong assumption 