### PR TITLE
feat: republish tracks on signal restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -45,19 +45,19 @@ checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -68,13 +68,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
+checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -113,15 +113,15 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -149,6 +149,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "block-buffer"
@@ -320,9 +326,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -348,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -367,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.95"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109308c20e8445959c2792e81871054c6a17e6976489a93d2769641a2ba5839c"
+checksum = "f68e12e817cb19eaab81aaec582b4052d07debd3c3c6b083b9d361db47c7dc9d"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -379,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.95"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf4c6755cdf10798b97510e0e2b3edb9573032bd9379de8fffa59d68165494f"
+checksum = "e789217e4ab7cf8cc9ce82253180a9fe331f35f5d339f0ccfe0270b39433f397"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -389,34 +395,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.23",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.95"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882074421238e84fe3b4c65d0081de34e5b323bf64555d3e61991f76eb64a7bb"
+checksum = "78a19f4c80fd9ab6c882286fa865e92e07688f4387370a209508014ead8751d0"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.95"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a076022ece33e7686fb76513518e219cca4fce5750a8ae6d1ce6c0f48fd1af9"
+checksum = "b8fcfa71f66c8563c4fa9dd2bb68368d50267856f831ac5d85367e0805f9606c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -427,6 +433,12 @@ name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
+name = "deranged"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8810e7e2cf385b1e9b50d68264908ec367ba642c96d02edfe61c39e88e2a3c01"
 
 [[package]]
 name = "digest"
@@ -447,9 +459,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encoding_rs"
@@ -475,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -496,12 +508,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fixedbitset"
@@ -516,7 +525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -615,7 +624,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -683,9 +692,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -705,6 +714,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hdrhistogram"
@@ -727,18 +742,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hmac"
@@ -791,9 +797,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -815,10 +821,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "rustls",
@@ -868,7 +875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -881,39 +888,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -929,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jni"
@@ -966,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -993,24 +979,24 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "livekit"
@@ -1121,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "matchers"
@@ -1131,14 +1117,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
 name = "matchit"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+checksum = "67827e6ea8ee8a7c4a72227ef4fc08957040acffdb5f122733b24fa12daff41b"
 
 [[package]]
 name = "memchr"
@@ -1157,15 +1143,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -1223,28 +1200,28 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.30.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
@@ -1257,11 +1234,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1278,7 +1255,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1298,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
@@ -1332,7 +1309,7 @@ dependencies = [
  "redox_syscall 0.3.5",
  "smallvec",
  "thread-id",
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1428,14 +1405,14 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -1467,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1530,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -1573,7 +1550,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1582,18 +1559,19 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.4",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1606,6 +1584,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,9 +1602,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
@@ -1682,13 +1671,12 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
@@ -1696,21 +1684,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.2",
  "sct",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -1720,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
 ]
@@ -1738,16 +1726,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.13"
+name = "rustls-webpki"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -1760,24 +1758,24 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scratch"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
 name = "sct"
@@ -1791,11 +1789,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1804,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1814,35 +1812,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1874,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1912,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -1951,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1968,11 +1966,10 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
@@ -2006,7 +2003,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2032,10 +2029,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
 dependencies = [
+ "deranged",
  "serde",
  "time-core",
 ]
@@ -2063,11 +2061,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2099,7 +2098,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2245,7 +2244,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2315,9 +2314,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -2387,11 +2386,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -2403,9 +2401,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2413,24 +2411,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2440,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2450,28 +2448,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2502,7 +2500,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
- "rustls-webpki",
+ "rustls-webpki 0.100.1",
 ]
 
 [[package]]
@@ -2574,21 +2572,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
@@ -2602,7 +2585,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -2622,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "reqwest",
+ "scopeguard",
  "serde",
  "serde_json",
  "sha2",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -45,9 +45,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -79,18 +79,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android-activity"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c77a0045eda8b888c76ea473c2b0515ba6f471d318f8927c5c72240937035a6"
+checksum = "64529721f27c2314ced0890ce45e469574a73e5e6fdd6e9da1860eb29285f5e0"
 dependencies = [
  "android-properties",
  "bitflags 1.3.2",
@@ -101,7 +101,7 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys",
- "num_enum",
+ "num_enum 0.6.1",
 ]
 
 [[package]]
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "arboard"
@@ -175,9 +175,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "ash"
@@ -190,13 +190,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -258,15 +258,15 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -328,9 +328,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.1"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "block"
@@ -389,7 +389,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -427,10 +427,11 @@ dependencies = [
 
 [[package]]
 name = "calloop"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a59225be45a478d772ce015d9743e49e92798ece9e34eda9a6aa2a6a7f40192"
+checksum = "52e0d00eb1ea24371a97d2da6201c6747a633dc6dc1988ef503403b4c59504a8"
 dependencies = [
+ "bitflags 1.3.2",
  "log",
  "nix 0.25.1",
  "slotmap",
@@ -633,21 +634,20 @@ dependencies = [
 
 [[package]]
 name = "core-graphics-types"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
+checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "foreign-types",
  "libc",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -684,22 +684,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.94"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+checksum = "f68e12e817cb19eaab81aaec582b4052d07debd3c3c6b083b9d361db47c7dc9d"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.94"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+checksum = "e789217e4ab7cf8cc9ce82253180a9fe331f35f5d339f0ccfe0270b39433f397"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -744,24 +744,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.94"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+checksum = "78a19f4c80fd9ab6c882286fa865e92e07688f4387370a209508014ead8751d0"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.94"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+checksum = "b8fcfa71f66c8563c4fa9dd2bb68368d50267856f831ac5d85367e0805f9606c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -780,6 +780,12 @@ name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
+name = "deranged"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8810e7e2cf385b1e9b50d68264908ec367ba642c96d02edfe61c39e88e2a3c01"
 
 [[package]]
 name = "digest"
@@ -821,11 +827,11 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dlib"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.0",
 ]
 
 [[package]]
@@ -923,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
@@ -948,13 +954,13 @@ dependencies = [
 
 [[package]]
 name = "enumn"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9838a970f5de399d3070ae1739e131986b2f5dcc223c7423ca0927e3a878522"
+checksum = "b893c4eb2dc092c811165f84dc7447fae16fb66521717968c34c509b39b1a5c5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -990,15 +996,15 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1027,15 +1033,15 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.6.3"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd2162b720141a91a054640662d3edce3d50a944a50ffca5313cd951abb35b4"
+checksum = "d1e481eb11a482815d3e9d618db8c42a93207134662873809335a92327440c18"
 dependencies = [
  "bit_field",
  "flume",
  "half",
  "lebe",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -1043,12 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fdeflate"
@@ -1072,7 +1075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1111,9 +1114,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -1184,7 +1187,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1239,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1262,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -1338,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -1415,18 +1418,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hexf-parse"
@@ -1557,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1626,30 +1620,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -1665,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jni"
@@ -1755,9 +1737,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -1781,18 +1763,18 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "livekit"
@@ -1870,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1899,14 +1881,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
 name = "matchit"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+checksum = "67827e6ea8ee8a7c4a72227ef4fc08957040acffdb5f122733b24fa12daff41b"
 
 [[package]]
 name = "memchr"
@@ -1934,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -1969,15 +1951,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
@@ -1988,14 +1961,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2019,9 +1992,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "naga"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d3edd593521f4a1dfd9b25193ed0224764572905f013d30ca5fbb85e010876"
+checksum = "bbcc2e0513220fd2b598e6068608d4462db20322c0e77e47f6f488dfcfc279cb"
 dependencies = [
  "bit-set",
  "bitflags 1.3.2",
@@ -2073,7 +2046,7 @@ dependencies = [
  "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys",
- "num_enum",
+ "num_enum 0.5.11",
  "raw-window-handle",
  "thiserror",
 ]
@@ -2157,20 +2130,20 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2180,7 +2153,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -2193,6 +2175,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2262,18 +2256,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
@@ -2298,7 +2292,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2349,18 +2343,18 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "backtrace",
  "cfg-if",
  "libc",
  "petgraph",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
  "thread-id",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -2425,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -2441,29 +2435,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -2479,15 +2473,15 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "png"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaeebc51f9e7d2c150d3f3bfeb667f2aa985db5ef1e3d212847bdedb488beeaa"
+checksum = "59871cc5b6cce7eaccca5a802b4173377a1c2ba90654246789a8fa2334426d11"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2602,9 +2596,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -2704,13 +2698,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.4",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -2723,6 +2718,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,9 +2736,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "renderdoc-sys"
@@ -2823,13 +2829,12 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
@@ -2837,13 +2842,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.3"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.1",
+ "rustls-webpki 0.101.2",
  "sct",
 ]
 
@@ -2880,9 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
 dependencies = [
  "ring",
  "untrusted",
@@ -2896,9 +2901,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -2922,11 +2927,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2937,15 +2942,15 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scratch"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
 name = "sct"
@@ -2972,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -2985,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2995,35 +3000,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -3055,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3084,9 +3089,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
@@ -3108,9 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -3190,9 +3195,9 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strict-num"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df65f20698aeed245efdde3628a6b559ea1239bbb871af1b6e3b58c413b2bd1"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "subtle"
@@ -3213,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3230,11 +3235,10 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
@@ -3268,7 +3272,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3305,10 +3309,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
 dependencies = [
+ "deranged",
  "serde",
  "time-core",
 ]
@@ -3361,11 +3366,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -3397,7 +3403,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3470,9 +3476,9 @@ checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",
@@ -3559,7 +3565,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3596,9 +3602,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "ttf-parser"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dcf002ae3b32cd25400d6df128c5babec3927cd1eb7ce813cfff20eb6c3746"
+checksum = "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33"
 
 [[package]]
 name = "tungstenite"
@@ -3644,9 +3650,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -3677,9 +3683,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3728,11 +3734,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -3763,15 +3768,15 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3797,7 +3802,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3977,9 +3982,9 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "wgpu"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3059ea4ddec41ca14f356833e2af65e7e38c0a8f91273867ed526fb9bafcca95"
+checksum = "480c965c9306872eb6255fa55e4b4953be55a8b64d57e61d7ff840d3dcc051cd"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4007,7 +4012,7 @@ checksum = "8f478237b4bf0d5b70a39898a66fa67ca3a007d79f2520485b8b0c3dfc46f8c2"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags 2.3.1",
+ "bitflags 2.3.3",
  "codespan-reporting",
  "log",
  "naga",
@@ -4024,15 +4029,15 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41af2ea7d87bd41ad0a37146252d5f7c26490209f47f544b2ee3b3ff34c7732e"
+checksum = "1ecb3258078e936deee14fd4e0febe1cfe9bbb5ffef165cb60218d2ee5eb4448"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.3.1",
+ "bitflags 2.3.3",
  "block",
  "core-graphics-types",
  "d3d12",
@@ -4066,11 +4071,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd33a976130f03dcdcd39b3810c0c3fc05daf86f0aaf867db14bfb7c4a9a32b"
+checksum = "d0c153280bb108c2979eb5c7391cb18c56642dd3c072e55f52065e13e2a1252a"
 dependencies = [
- "bitflags 2.3.1",
+ "bitflags 2.3.3",
  "js-sys",
  "web-sys",
 ]
@@ -4163,21 +4168,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
@@ -4191,7 +4181,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -4211,9 +4201,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -4345,9 +4335,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "8bd122eb777186e60c3fdf765a58ac76e41c582f1f535fbf3314434c6b58f3f7"
 dependencies = [
  "memchr",
 ]
@@ -4405,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.13"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8f380ae16a37b30e6a2cf67040608071384b1450c189e61bea3ff57cde922d"
+checksum = "47430998a7b5d499ccee752b41567bc3afc57e1327dc855b1a2aa44ce29b5fa1"
 
 [[package]]
 name = "zip"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1806,6 +1806,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "reqwest",
+ "scopeguard",
  "serde",
  "serde_json",
  "sha2",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -181,9 +181,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ash"
-version = "0.37.2+1.3.238"
+version = "0.37.3+1.3.251"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28bf19c1f0a470be5fbf7522a308a05df06610252c5bcf5143e1b23f629a9a03"
+checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
 dependencies = [
  "libloading 0.7.4",
 ]
@@ -1274,9 +1274,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "glow"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e007a07a24de5ecae94160f141029e9a347282cfe25d1d58d85d845cf3130f1"
+checksum = "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1543,6 +1543,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2034,6 +2047,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,10 +2276,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "openssl"
+version = "0.10.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "orbclient"
@@ -2687,10 +2756,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2701,6 +2772,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -3329,6 +3401,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,8 +3439,10 @@ checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "rustls",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.23.1",
@@ -3528,6 +3612,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand",
  "rustls",
  "sha1",
@@ -3614,6 +3699,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,9 +3744,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3663,9 +3754,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
@@ -3690,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3700,9 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3713,9 +3804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wayland-client"
@@ -3792,9 +3883,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/examples/wgpu_room/Cargo.toml
+++ b/examples/wgpu_room/Cargo.toml
@@ -8,8 +8,8 @@ default = []
 tracing = ["console-subscriber", "tokio/tracing"]
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
-livekit = { path = "../../livekit", version = "0.1.3" }
+tokio = { version = "1", features = ["full", "parking_lot"] }
+livekit = { path = "../../livekit", version = "0.1.3", features = ["native-tls"] }
 futures = "0.3"
 winit = "0.28"
 parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }

--- a/examples/wgpu_room/src/logo_track.rs
+++ b/examples/wgpu_room/src/logo_track.rs
@@ -100,7 +100,7 @@ impl LogoTrack {
 
             self.room
                 .local_participant()
-                .unpublish_track(handle.track.sid(), true)
+                .unpublish_track(&handle.track.sid())
                 .await?;
         }
         Ok(())

--- a/examples/wgpu_room/src/sine_track.rs
+++ b/examples/wgpu_room/src/sine_track.rs
@@ -87,7 +87,7 @@ impl SineTrack {
             handle.task.await.ok();
             self.room
                 .local_participant()
-                .unpublish_track(handle.track.sid(), true)
+                .unpublish_track(&handle.track.sid())
                 .await?;
         }
 

--- a/livekit-api/Cargo.toml
+++ b/livekit-api/Cargo.toml
@@ -46,3 +46,4 @@ tokio = { version = "1", features = ["full"], optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["sink"], optional = true }
 
 reqwest = { version = "0.11", default-features = false, features = ["json"], optional = true }
+scopeguard = "1.2.0"

--- a/livekit-api/src/services/egress.rs
+++ b/livekit-api/src/services/egress.rs
@@ -49,7 +49,7 @@ pub enum EgressOutput {
 
 #[derive(Debug, Clone)]
 pub enum TrackEgressOutput {
-    File(proto::DirectFileOutput),
+    File(Box<proto::DirectFileOutput>),
     WebSocket(String),
 }
 
@@ -66,7 +66,7 @@ pub struct EgressListOptions {
     pub active: bool,
 }
 
-const SVC: &'static str = "Egress";
+const SVC: &str = "Egress";
 
 #[derive(Debug)]
 pub struct EgressClient {
@@ -200,7 +200,7 @@ impl EgressClient {
                     room_name: room.to_string(),
                     output: match output {
                         TrackEgressOutput::File(f) => {
-                            Some(proto::track_egress_request::Output::File(f))
+                            Some(proto::track_egress_request::Output::File(*f))
                         }
                         TrackEgressOutput::WebSocket(url) => {
                             Some(proto::track_egress_request::Output::WebsocketUrl(url))

--- a/livekit-api/src/services/ingress.rs
+++ b/livekit-api/src/services/ingress.rs
@@ -33,7 +33,7 @@ pub enum IngressListFilter {
     Room(String),
 }
 
-const SVC: &'static str = "Ingress";
+const SVC: &str = "Ingress";
 
 #[derive(Debug)]
 pub struct IngressClient {

--- a/livekit-api/src/services/ingress.rs
+++ b/livekit-api/src/services/ingress.rs
@@ -31,6 +31,7 @@ pub struct IngressOptions {
 pub enum IngressListFilter {
     All,
     Room(String),
+    IngressId(String),
 }
 
 const SVC: &str = "Ingress";
@@ -120,9 +121,13 @@ impl IngressClient {
                 SVC,
                 "ListIngress",
                 proto::ListIngressRequest {
+                    ingress_id: match filter.clone() {
+                        IngressListFilter::IngressId(id) => id,
+                        _ => Default::default(),
+                    },
                     room_name: match filter {
-                        IngressListFilter::All => Default::default(),
                         IngressListFilter::Room(room) => room,
+                        _ => Default::default(),
                     },
                 },
                 self.base.auth_header(VideoGrants {

--- a/livekit-api/src/services/mod.rs
+++ b/livekit-api/src/services/mod.rs
@@ -17,13 +17,13 @@ use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use std::fmt::Debug;
 use thiserror::Error;
 
-pub mod room;
 pub mod egress;
 pub mod ingress;
+pub mod room;
 
 mod twirp_client;
 
-pub const LIVEKIT_PACKAGE: &'static str = "livekit";
+pub const LIVEKIT_PACKAGE: &str = "livekit";
 
 #[derive(Debug, Error)]
 pub enum ServiceError {

--- a/livekit-api/src/services/room.rs
+++ b/livekit-api/src/services/room.rs
@@ -17,7 +17,7 @@ use crate::services::twirp_client::TwirpClient;
 use crate::{access_token::VideoGrants, get_env_keys};
 use livekit_protocol as proto;
 
-const SVC: &'static str = "RoomService";
+const SVC: &str = "RoomService";
 
 #[derive(Debug, Clone, Default)]
 pub struct CreateRoomOptions {

--- a/livekit-api/src/signal_client/signal_stream.rs
+++ b/livekit-api/src/signal_client/signal_stream.rs
@@ -105,6 +105,7 @@ impl SignalStream {
                     signal,
                     response_chn,
                 } => {
+                    log::debug!("sending signal: {:?}", signal);
                     let data = Message::Binary(
                         proto::SignalRequest {
                             message: Some(signal),
@@ -148,7 +149,8 @@ impl SignalStream {
                         .expect("failed to decode SignalResponse");
 
                     let msg = res.message.unwrap();
-                    let _ = emitter.send(SignalEvent::Signal(msg));
+                    log::debug!("received signal: {:?}", msg);
+                    let _ = emitter.send(SignalEvent::Signal(Box::new(msg)));
                 }
                 Ok(Message::Ping(data)) => {
                     let _ = internal_tx

--- a/livekit-api/src/webhooks.rs
+++ b/livekit-api/src/webhooks.rs
@@ -51,8 +51,8 @@ impl WebhookReceiver {
         hasher.update(body);
         let hash = hasher.finalize();
 
-        let claim_hash = base64::engine::general_purpose::STANDARD.decode(&claims.sha256)?;
-        if &claim_hash[..] != &hash[..] {
+        let claim_hash = base64::engine::general_purpose::STANDARD.decode(claims.sha256)?;
+        if claim_hash[..] != hash[..] {
             return Err(WebhookError::InvalidSignature);
         }
 

--- a/livekit-ffi/Cargo.toml
+++ b/livekit-ffi/Cargo.toml
@@ -30,8 +30,8 @@ thiserror = "1.0.38"
 log = "0.4.17"
 dashmap = "5.4.0"
 env_logger = "0.10.0"
-console-subscriber = { version = "0.1.10", features = ["parking_lot"], optional = true }
 downcast-rs = "1.2.0"
+console-subscriber = { version = "0.1.10", features = ["parking_lot"], optional = true }
 
 [build-dependencies]
 webrtc-sys-build = { path = "../webrtc-sys/build", version = "0.1.3" }

--- a/livekit-ffi/src/conversion/audio_frame.rs
+++ b/livekit-ffi/src/conversion/audio_frame.rs
@@ -31,7 +31,7 @@ impl From<proto::AudioSourceOptions> for AudioSourceOptions {
 impl proto::AudioFrameBufferInfo {
     pub fn from(handle_id: proto::FfiOwnedHandle, buffer: &AudioFrame) -> Self {
         Self {
-            handle: Some(handle_id.into()),
+            handle: Some(handle_id),
             data_ptr: buffer.data.as_ptr() as u64,
             samples_per_channel: buffer.samples_per_channel,
             sample_rate: buffer.sample_rate,
@@ -43,7 +43,7 @@ impl proto::AudioFrameBufferInfo {
 impl proto::AudioSourceInfo {
     pub fn from(handle_id: proto::FfiOwnedHandle, source: &FfiAudioSource) -> Self {
         Self {
-            handle: Some(handle_id.into()),
+            handle: Some(handle_id),
             r#type: source.source_type as i32,
         }
     }
@@ -52,7 +52,7 @@ impl proto::AudioSourceInfo {
 impl proto::AudioStreamInfo {
     pub fn from(handle_id: proto::FfiOwnedHandle, stream: &FfiAudioStream) -> Self {
         Self {
-            handle: Some(handle_id.into()),
+            handle: Some(handle_id),
             r#type: stream.stream_type as i32,
         }
     }

--- a/livekit-ffi/src/conversion/room.rs
+++ b/livekit-ffi/src/conversion/room.rs
@@ -68,15 +68,13 @@ impl From<DataPacketKind> for proto::DataPacketKind {
 impl From<proto::TrackPublishOptions> for TrackPublishOptions {
     fn from(opts: proto::TrackPublishOptions) -> Self {
         Self {
+            video_codec: opts.video_codec().into(),
+            source: opts.source().into(),
             video_encoding: opts.video_encoding.map(Into::into),
             audio_encoding: opts.audio_encoding.map(Into::into),
-            video_codec: proto::VideoCodec::from_i32(opts.video_codec)
-                .unwrap()
-                .into(),
             dtx: opts.dtx,
             red: opts.red,
             simulcast: opts.simulcast,
-            source: proto::TrackSource::from_i32(opts.source).unwrap().into(),
         }
     }
 }

--- a/livekit-ffi/src/conversion/video_frame.rs
+++ b/livekit-ffi/src/conversion/video_frame.rs
@@ -162,8 +162,8 @@ macro_rules! impl_biyuv_into {
                 handle: Some(handle),
                 chroma_width: buffer.chroma_width(),
                 chroma_height: buffer.chroma_height(),
-                stride_y: stride_y,
-                stride_uv: stride_uv,
+                stride_y,
+                stride_uv,
                 data_y_ptr: data_y.as_ptr() as u64,
                 data_uv_ptr: data_uv.as_ptr() as u64,
             }
@@ -286,7 +286,7 @@ impl proto::VideoFrameBufferInfo {
 impl proto::VideoSourceInfo {
     pub fn from(handle_id: proto::FfiOwnedHandle, source: &FfiVideoSource) -> Self {
         Self {
-            handle: Some(handle_id.into()),
+            handle: Some(handle_id),
             r#type: source.source_type as i32,
         }
     }
@@ -295,7 +295,7 @@ impl proto::VideoSourceInfo {
 impl proto::VideoStreamInfo {
     pub fn from(handle_id: proto::FfiOwnedHandle, stream: &FfiVideoStream) -> Self {
         Self {
-            handle: Some(handle_id.into()),
+            handle: Some(handle_id),
             r#type: stream.stream_type as i32,
         }
     }

--- a/livekit-ffi/src/lib.rs
+++ b/livekit-ffi/src/lib.rs
@@ -20,7 +20,6 @@ use std::{borrow::Cow, sync::Arc};
 use thiserror::Error;
 
 mod conversion;
-#[path = "livekit.proto.rs"]
 mod proto;
 mod server;
 

--- a/livekit-ffi/src/lib.rs
+++ b/livekit-ffi/src/lib.rs
@@ -47,8 +47,11 @@ lazy_static! {
     pub static ref FFI_SERVER: server::FfiServer = server::FfiServer::default();
 }
 
+/// # Safety
+///
+/// The foreign language must only provide valid pointers
 #[no_mangle]
-pub extern "C" fn livekit_ffi_request(
+pub unsafe extern "C" fn livekit_ffi_request(
     data: *const u8,
     len: usize,
     res_ptr: *mut *const u8,

--- a/livekit-ffi/src/livekit.proto.rs
+++ b/livekit-ffi/src/livekit.proto.rs
@@ -2,46 +2,46 @@
 /// # Safety
 /// The foreign language is responsable for disposing handles
 /// Forgetting to dispose the handle may lead to memory leaks
-/// 
+///
 /// Dropping a handle doesn't necessarily mean that the object is destroyed if it is still used
 /// on the FfiServer (Atomic reference counting)
-/// 
-/// When refering to a handle without owning it, we just use a uint32 without this message. 
+///
+/// When refering to a handle without owning it, we just use a uint32 without this message.
 /// (the variable name is suffixed with "_handle")
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FfiOwnedHandle {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub id: u64,
 }
 /// Create a new VideoTrack from a VideoSource
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateVideoTrackRequest {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub source_handle: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateVideoTrackResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub track: ::core::option::Option<TrackInfo>,
 }
 /// Create a new AudioTrack from a AudioSource
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateAudioTrackRequest {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub source_handle: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateAudioTrackResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub track: ::core::option::Option<TrackInfo>,
 }
 //
@@ -50,50 +50,49 @@ pub struct CreateAudioTrackResponse {
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TrackEvent {
-}
+pub struct TrackEvent {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackPublicationInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub sid: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub name: ::prost::alloc::string::String,
-    #[prost(enumeration="TrackKind", tag="4")]
+    #[prost(enumeration = "TrackKind", tag = "4")]
     pub kind: i32,
-    #[prost(enumeration="TrackSource", tag="5")]
+    #[prost(enumeration = "TrackSource", tag = "5")]
     pub source: i32,
-    #[prost(bool, tag="6")]
+    #[prost(bool, tag = "6")]
     pub simulcasted: bool,
-    #[prost(uint32, tag="7")]
+    #[prost(uint32, tag = "7")]
     pub width: u32,
-    #[prost(uint32, tag="8")]
+    #[prost(uint32, tag = "8")]
     pub height: u32,
-    #[prost(string, tag="9")]
+    #[prost(string, tag = "9")]
     pub mime_type: ::prost::alloc::string::String,
-    #[prost(bool, tag="10")]
+    #[prost(bool, tag = "10")]
     pub muted: bool,
-    #[prost(bool, tag="11")]
+    #[prost(bool, tag = "11")]
     pub remote: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub sid: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub name: ::prost::alloc::string::String,
-    #[prost(enumeration="TrackKind", tag="4")]
+    #[prost(enumeration = "TrackKind", tag = "4")]
     pub kind: i32,
-    #[prost(enumeration="StreamState", tag="5")]
+    #[prost(enumeration = "StreamState", tag = "5")]
     pub stream_state: i32,
-    #[prost(bool, tag="6")]
+    #[prost(bool, tag = "6")]
     pub muted: bool,
-    #[prost(bool, tag="7")]
+    #[prost(bool, tag = "7")]
     pub remote: bool,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -192,15 +191,15 @@ impl StreamState {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ParticipantInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub sid: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub name: ::prost::alloc::string::String,
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub identity: ::prost::alloc::string::String,
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub metadata: ::prost::alloc::string::String,
 }
 /// Allocate a new VideoFrameBuffer
@@ -208,17 +207,17 @@ pub struct ParticipantInfo {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AllocVideoBufferRequest {
     /// Only I420 is supported atm
-    #[prost(enumeration="VideoFrameBufferType", tag="1")]
+    #[prost(enumeration = "VideoFrameBufferType", tag = "1")]
     pub r#type: i32,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub width: u32,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub height: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AllocVideoBufferResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub buffer: ::core::option::Option<VideoFrameBufferInfo>,
 }
 /// Create a new VideoStream
@@ -226,15 +225,15 @@ pub struct AllocVideoBufferResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewVideoStreamRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub track_handle: u64,
-    #[prost(enumeration="VideoStreamType", tag="2")]
+    #[prost(enumeration = "VideoStreamType", tag = "2")]
     pub r#type: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewVideoStreamResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub stream: ::core::option::Option<VideoStreamInfo>,
 }
 /// Create a new VideoSource
@@ -242,59 +241,58 @@ pub struct NewVideoStreamResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewVideoSourceRequest {
-    #[prost(enumeration="VideoSourceType", tag="1")]
+    #[prost(enumeration = "VideoSourceType", tag = "1")]
     pub r#type: i32,
     /// Used to determine which encodings to use + simulcast layers
-    /// Most of the time it corresponds to the source resolution 
-    #[prost(message, optional, tag="2")]
+    /// Most of the time it corresponds to the source resolution
+    #[prost(message, optional, tag = "2")]
     pub resolution: ::core::option::Option<VideoSourceResolution>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewVideoSourceResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub source: ::core::option::Option<VideoSourceInfo>,
 }
 /// Push a frame to a VideoSource
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CaptureVideoFrameRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub source_handle: u64,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub frame: ::core::option::Option<VideoFrameInfo>,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub buffer_handle: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CaptureVideoFrameResponse {
-}
+pub struct CaptureVideoFrameResponse {}
 /// Convert a RGBA frame to a I420 YUV frame
 /// Or convert another YUV frame format to I420
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ToI420Request {
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub flip_y: bool,
-    #[prost(oneof="to_i420_request::From", tags="2, 3")]
+    #[prost(oneof = "to_i420_request::From", tags = "2, 3")]
     pub from: ::core::option::Option<to_i420_request::From>,
 }
 /// Nested message and enum types in `ToI420Request`.
 pub mod to_i420_request {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum From {
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Argb(super::ArgbBufferInfo),
-        #[prost(uint64, tag="3")]
+        #[prost(uint64, tag = "3")]
         BufferHandle(u64),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ToI420Response {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub buffer: ::core::option::Option<VideoFrameBufferInfo>,
 }
 /// Convert a YUV frame to a RGBA frame
@@ -302,25 +300,24 @@ pub struct ToI420Response {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ToArgbRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub buffer_handle: u64,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub dst_ptr: u64,
-    #[prost(enumeration="VideoFormatType", tag="3")]
+    #[prost(enumeration = "VideoFormatType", tag = "3")]
     pub dst_format: i32,
-    #[prost(uint32, tag="4")]
+    #[prost(uint32, tag = "4")]
     pub dst_stride: u32,
-    #[prost(uint32, tag="5")]
+    #[prost(uint32, tag = "5")]
     pub dst_width: u32,
-    #[prost(uint32, tag="6")]
+    #[prost(uint32, tag = "6")]
     pub dst_height: u32,
-    #[prost(bool, tag="7")]
+    #[prost(bool, tag = "7")]
     pub flip_y: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ToArgbResponse {
-}
+pub struct ToArgbResponse {}
 //
 // VideoFrame buffers
 //
@@ -328,145 +325,145 @@ pub struct ToArgbResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoResolution {
-    #[prost(uint32, tag="1")]
+    #[prost(uint32, tag = "1")]
     pub width: u32,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub height: u32,
-    #[prost(double, tag="3")]
+    #[prost(double, tag = "3")]
     pub frame_rate: f64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArgbBufferInfo {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub ptr: u64,
-    #[prost(enumeration="VideoFormatType", tag="2")]
+    #[prost(enumeration = "VideoFormatType", tag = "2")]
     pub format: i32,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub stride: u32,
-    #[prost(uint32, tag="4")]
+    #[prost(uint32, tag = "4")]
     pub width: u32,
-    #[prost(uint32, tag="5")]
+    #[prost(uint32, tag = "5")]
     pub height: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoFrameInfo {
     /// In microseconds
-    #[prost(int64, tag="1")]
+    #[prost(int64, tag = "1")]
     pub timestamp_us: i64,
-    #[prost(enumeration="VideoRotation", tag="2")]
+    #[prost(enumeration = "VideoRotation", tag = "2")]
     pub rotation: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoFrameBufferInfo {
-    #[prost(enumeration="VideoFrameBufferType", tag="2")]
+    #[prost(enumeration = "VideoFrameBufferType", tag = "2")]
     pub buffer_type: i32,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub width: u32,
-    #[prost(uint32, tag="4")]
+    #[prost(uint32, tag = "4")]
     pub height: u32,
-    #[prost(oneof="video_frame_buffer_info::Buffer", tags="5, 6, 7")]
+    #[prost(oneof = "video_frame_buffer_info::Buffer", tags = "5, 6, 7")]
     pub buffer: ::core::option::Option<video_frame_buffer_info::Buffer>,
 }
 /// Nested message and enum types in `VideoFrameBufferInfo`.
 pub mod video_frame_buffer_info {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Buffer {
-        #[prost(message, tag="5")]
+        #[prost(message, tag = "5")]
         Yuv(super::PlanarYuvBufferInfo),
-        #[prost(message, tag="6")]
+        #[prost(message, tag = "6")]
         BiYuv(super::BiplanarYuvBufferInfo),
-        #[prost(message, tag="7")]
+        #[prost(message, tag = "7")]
         Native(super::NativeBufferInfo),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PlanarYuvBufferInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub chroma_width: u32,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub chroma_height: u32,
-    #[prost(uint32, tag="4")]
+    #[prost(uint32, tag = "4")]
     pub stride_y: u32,
-    #[prost(uint32, tag="5")]
+    #[prost(uint32, tag = "5")]
     pub stride_u: u32,
-    #[prost(uint32, tag="6")]
+    #[prost(uint32, tag = "6")]
     pub stride_v: u32,
-    #[prost(uint32, tag="7")]
+    #[prost(uint32, tag = "7")]
     pub stride_a: u32,
     /// *const u8 or *const u16
-    #[prost(uint64, tag="8")]
+    #[prost(uint64, tag = "8")]
     pub data_y_ptr: u64,
-    #[prost(uint64, tag="9")]
+    #[prost(uint64, tag = "9")]
     pub data_u_ptr: u64,
-    #[prost(uint64, tag="10")]
+    #[prost(uint64, tag = "10")]
     pub data_v_ptr: u64,
     /// nullptr = no alpha
-    #[prost(uint64, tag="11")]
+    #[prost(uint64, tag = "11")]
     pub data_a_ptr: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BiplanarYuvBufferInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub chroma_width: u32,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub chroma_height: u32,
-    #[prost(uint32, tag="4")]
+    #[prost(uint32, tag = "4")]
     pub stride_y: u32,
-    #[prost(uint32, tag="5")]
+    #[prost(uint32, tag = "5")]
     pub stride_uv: u32,
-    #[prost(uint64, tag="6")]
+    #[prost(uint64, tag = "6")]
     pub data_y_ptr: u64,
-    #[prost(uint64, tag="7")]
+    #[prost(uint64, tag = "7")]
     pub data_uv_ptr: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NativeBufferInfo {
     /// TODO(theomonnom): Expose graphic context?
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoStreamInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(enumeration="VideoStreamType", tag="2")]
+    #[prost(enumeration = "VideoStreamType", tag = "2")]
     pub r#type: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoStreamEvent {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub handle: u64,
-    #[prost(oneof="video_stream_event::Message", tags="2")]
+    #[prost(oneof = "video_stream_event::Message", tags = "2")]
     pub message: ::core::option::Option<video_stream_event::Message>,
 }
 /// Nested message and enum types in `VideoStreamEvent`.
 pub mod video_stream_event {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Message {
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         FrameReceived(super::VideoFrameReceived),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoFrameReceived {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub frame: ::core::option::Option<VideoFrameInfo>,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub buffer: ::core::option::Option<VideoFrameBufferInfo>,
 }
 //
@@ -476,17 +473,17 @@ pub struct VideoFrameReceived {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoSourceResolution {
-    #[prost(uint32, tag="1")]
+    #[prost(uint32, tag = "1")]
     pub width: u32,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub height: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoSourceInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(enumeration="VideoSourceType", tag="2")]
+    #[prost(enumeration = "VideoSourceType", tag = "2")]
     pub r#type: i32,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -686,43 +683,43 @@ impl VideoSourceType {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectRequest {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub url: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub token: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub options: ::core::option::Option<RoomOptions>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectResponse {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectCallback {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub room: ::core::option::Option<RoomInfo>,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub local_participant: ::core::option::Option<connect_callback::ParticipantWithTracks>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub participants: ::prost::alloc::vec::Vec<connect_callback::ParticipantWithTracks>,
 }
 /// Nested message and enum types in `ConnectCallback`.
 pub mod connect_callback {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ParticipantWithTracks {
-        #[prost(message, optional, tag="1")]
+        #[prost(message, optional, tag = "1")]
         pub participant: ::core::option::Option<super::ParticipantInfo>,
         /// TrackInfo are not needed here, if we're subscribed to a track, the FfiServer will send
         /// a TrackSubscribed event
-        #[prost(message, repeated, tag="2")]
+        #[prost(message, repeated, tag = "2")]
         pub publications: ::prost::alloc::vec::Vec<super::TrackPublicationInfo>,
     }
 }
@@ -730,118 +727,117 @@ pub mod connect_callback {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DisconnectRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub room_handle: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DisconnectResponse {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DisconnectCallback {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
 }
 /// Publish a track to the room
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublishTrackRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub local_participant_handle: u64,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub track_handle: u64,
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub options: ::core::option::Option<TrackPublishOptions>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublishTrackResponse {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublishTrackCallback {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
     /// The TrackPublicationInfo comes from the LocalTrackPublished event
     /// and the FfiClient musts wait for it
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub track_sid: ::prost::alloc::string::String,
 }
 /// Unpublish a track from the room
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnpublishTrackRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub local_participant_handle: u64,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub track_sid: ::prost::alloc::string::String,
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub stop_on_unpublish: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnpublishTrackResponse {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnpublishTrackCallback {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Publish data to other participants
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublishDataRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub local_participant_handle: u64,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub data_ptr: u64,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub data_len: u64,
-    #[prost(enumeration="DataPacketKind", tag="4")]
+    #[prost(enumeration = "DataPacketKind", tag = "4")]
     pub kind: i32,
     /// destination
-    #[prost(string, repeated, tag="5")]
+    #[prost(string, repeated, tag = "5")]
     pub destination_sids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublishDataResponse {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublishDataCallback {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Change the "desire" to subs2ribe to a track
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetSubscribedRequest {
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub subscribe: bool,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub publication_handle: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SetSubscribedResponse {
-}
+pub struct SetSubscribedResponse {}
 //
 // Options
 //
@@ -849,159 +845,162 @@ pub struct SetSubscribedResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoEncoding {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub max_bitrate: u64,
-    #[prost(double, tag="2")]
+    #[prost(double, tag = "2")]
     pub max_framerate: f64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AudioEncoding {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub max_bitrate: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackPublishOptions {
     /// encodings are optional
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub video_encoding: ::core::option::Option<VideoEncoding>,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub audio_encoding: ::core::option::Option<AudioEncoding>,
-    #[prost(enumeration="VideoCodec", tag="3")]
+    #[prost(enumeration = "VideoCodec", tag = "3")]
     pub video_codec: i32,
-    #[prost(bool, tag="4")]
+    #[prost(bool, tag = "4")]
     pub dtx: bool,
-    #[prost(bool, tag="5")]
+    #[prost(bool, tag = "5")]
     pub red: bool,
-    #[prost(bool, tag="6")]
+    #[prost(bool, tag = "6")]
     pub simulcast: bool,
-    #[prost(enumeration="TrackSource", tag="7")]
+    #[prost(enumeration = "TrackSource", tag = "7")]
     pub source: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RoomOptions {
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub auto_subscribe: bool,
-    #[prost(bool, tag="2")]
+    #[prost(bool, tag = "2")]
     pub adaptive_stream: bool,
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub dynacast: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BufferInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub data_ptr: u64,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub data_len: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RoomEvent {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub room_handle: u64,
-    #[prost(oneof="room_event::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20")]
+    #[prost(
+        oneof = "room_event::Message",
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
+    )]
     pub message: ::core::option::Option<room_event::Message>,
 }
 /// Nested message and enum types in `RoomEvent`.
 pub mod room_event {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Message {
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         ParticipantConnected(super::ParticipantConnected),
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         ParticipantDisconnected(super::ParticipantDisconnected),
-        #[prost(message, tag="4")]
+        #[prost(message, tag = "4")]
         LocalTrackPublished(super::LocalTrackPublished),
-        #[prost(message, tag="5")]
+        #[prost(message, tag = "5")]
         LocalTrackUnpublished(super::LocalTrackUnpublished),
-        #[prost(message, tag="6")]
+        #[prost(message, tag = "6")]
         TrackPublished(super::TrackPublished),
-        #[prost(message, tag="7")]
+        #[prost(message, tag = "7")]
         TrackUnpublished(super::TrackUnpublished),
-        #[prost(message, tag="8")]
+        #[prost(message, tag = "8")]
         TrackSubscribed(super::TrackSubscribed),
-        #[prost(message, tag="9")]
+        #[prost(message, tag = "9")]
         TrackUnsubscribed(super::TrackUnsubscribed),
-        #[prost(message, tag="10")]
+        #[prost(message, tag = "10")]
         TrackSubscriptionFailed(super::TrackSubscriptionFailed),
-        #[prost(message, tag="11")]
+        #[prost(message, tag = "11")]
         TrackMuted(super::TrackMuted),
-        #[prost(message, tag="12")]
+        #[prost(message, tag = "12")]
         TrackUnmuted(super::TrackUnmuted),
-        #[prost(message, tag="13")]
+        #[prost(message, tag = "13")]
         ActiveSpeakersChanged(super::ActiveSpeakersChanged),
-        #[prost(message, tag="14")]
+        #[prost(message, tag = "14")]
         ConnectionQualityChanged(super::ConnectionQualityChanged),
-        #[prost(message, tag="15")]
+        #[prost(message, tag = "15")]
         DataReceived(super::DataReceived),
-        #[prost(message, tag="16")]
+        #[prost(message, tag = "16")]
         ConnectionStateChanged(super::ConnectionStateChanged),
-        #[prost(message, tag="17")]
+        #[prost(message, tag = "17")]
         Connected(super::Connected),
-        #[prost(message, tag="18")]
+        #[prost(message, tag = "18")]
         Disconnected(super::Disconnected),
-        #[prost(message, tag="19")]
+        #[prost(message, tag = "19")]
         Reconnecting(super::Reconnecting),
-        #[prost(message, tag="20")]
+        #[prost(message, tag = "20")]
         Reconnected(super::Reconnected),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RoomInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub sid: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub name: ::prost::alloc::string::String,
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub metadata: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ParticipantConnected {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub info: ::core::option::Option<ParticipantInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ParticipantDisconnected {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub participant_sid: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LocalTrackPublished {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub publication: ::core::option::Option<TrackPublicationInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LocalTrackUnpublished {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub publication_sid: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackPublished {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub publication: ::core::option::Option<TrackPublicationInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackUnpublished {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub publication_sid: ::prost::alloc::string::String,
 }
 /// Publication isn't needed for subscription events on the FFI
@@ -1009,93 +1008,89 @@ pub struct TrackUnpublished {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackSubscribed {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub track: ::core::option::Option<TrackInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackUnsubscribed {
     /// The FFI language can dispose/remove the VideoSink here
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub track_sid: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackSubscriptionFailed {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub track_sid: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub error: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackMuted {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub track_sid: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackUnmuted {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub track_sid: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ActiveSpeakersChanged {
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub participant_sids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectionQualityChanged {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(enumeration="ConnectionQuality", tag="2")]
+    #[prost(enumeration = "ConnectionQuality", tag = "2")]
     pub quality: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DataReceived {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub data: ::core::option::Option<BufferInfo>,
     /// Can be empty if the data is sent a server SDK
-    #[prost(string, optional, tag="2")]
+    #[prost(string, optional, tag = "2")]
     pub participant_sid: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(enumeration="DataPacketKind", tag="3")]
+    #[prost(enumeration = "DataPacketKind", tag = "3")]
     pub kind: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectionStateChanged {
-    #[prost(enumeration="ConnectionState", tag="1")]
+    #[prost(enumeration = "ConnectionState", tag = "1")]
     pub state: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Connected {
-}
+pub struct Connected {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Disconnected {
-}
+pub struct Disconnected {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Reconnecting {
-}
+pub struct Reconnecting {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Reconnected {
-}
+pub struct Reconnected {}
 //
 // Room
 //
@@ -1190,17 +1185,17 @@ impl DataPacketKind {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AllocAudioBufferRequest {
-    #[prost(uint32, tag="1")]
+    #[prost(uint32, tag = "1")]
     pub sample_rate: u32,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub num_channels: u32,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub samples_per_channel: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AllocAudioBufferResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub buffer: ::core::option::Option<AudioFrameBufferInfo>,
 }
 /// Create a new AudioStream
@@ -1208,73 +1203,71 @@ pub struct AllocAudioBufferResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewAudioStreamRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub track_handle: u64,
-    #[prost(enumeration="AudioStreamType", tag="2")]
+    #[prost(enumeration = "AudioStreamType", tag = "2")]
     pub r#type: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewAudioStreamResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub stream: ::core::option::Option<AudioStreamInfo>,
 }
 /// Create a new AudioSource
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewAudioSourceRequest {
-    #[prost(enumeration="AudioSourceType", tag="1")]
+    #[prost(enumeration = "AudioSourceType", tag = "1")]
     pub r#type: i32,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub options: ::core::option::Option<AudioSourceOptions>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewAudioSourceResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub source: ::core::option::Option<AudioSourceInfo>,
 }
-/// Push a frame to an AudioSource 
+/// Push a frame to an AudioSource
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CaptureAudioFrameRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub source_handle: u64,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub buffer_handle: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CaptureAudioFrameResponse {
-}
+pub struct CaptureAudioFrameResponse {}
 /// Create a new AudioResampler
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NewAudioResamplerRequest {
-}
+pub struct NewAudioResamplerRequest {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewAudioResamplerResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub resampler: ::core::option::Option<AudioResamplerInfo>,
 }
 /// Remix and resample an audio frame
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemixAndResampleRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub resampler_handle: u64,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub buffer_handle: u64,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub num_channels: u32,
-    #[prost(uint32, tag="4")]
+    #[prost(uint32, tag = "4")]
     pub sample_rate: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemixAndResampleResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub buffer: ::core::option::Option<AudioFrameBufferInfo>,
 }
 //
@@ -1284,47 +1277,47 @@ pub struct RemixAndResampleResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AudioFrameBufferInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
     /// *const i16
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub data_ptr: u64,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub num_channels: u32,
-    #[prost(uint32, tag="4")]
+    #[prost(uint32, tag = "4")]
     pub sample_rate: u32,
-    #[prost(uint32, tag="5")]
+    #[prost(uint32, tag = "5")]
     pub samples_per_channel: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AudioStreamInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(enumeration="AudioStreamType", tag="2")]
+    #[prost(enumeration = "AudioStreamType", tag = "2")]
     pub r#type: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AudioStreamEvent {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub source_handle: u64,
-    #[prost(oneof="audio_stream_event::Message", tags="2")]
+    #[prost(oneof = "audio_stream_event::Message", tags = "2")]
     pub message: ::core::option::Option<audio_stream_event::Message>,
 }
 /// Nested message and enum types in `AudioStreamEvent`.
 pub mod audio_stream_event {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Message {
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         FrameReceived(super::AudioFrameReceived),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AudioFrameReceived {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub frame: ::core::option::Option<AudioFrameBufferInfo>,
 }
 //
@@ -1334,19 +1327,19 @@ pub struct AudioFrameReceived {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AudioSourceOptions {
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub echo_cancellation: bool,
-    #[prost(bool, tag="2")]
+    #[prost(bool, tag = "2")]
     pub noise_suppression: bool,
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub auto_gain_control: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AudioSourceInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
-    #[prost(enumeration="AudioSourceType", tag="2")]
+    #[prost(enumeration = "AudioSourceType", tag = "2")]
     pub r#type: i32,
 }
 //
@@ -1356,7 +1349,7 @@ pub struct AudioSourceInfo {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AudioResamplerInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub handle: ::core::option::Option<FfiOwnedHandle>,
 }
 //
@@ -1432,7 +1425,7 @@ impl AudioSourceType {
 //    that it receives from the server.
 //
 // Therefore, the ffi client is easier to implement if there is less handles to manage.
-// 
+//
 // - We are mainly using FfiHandle on info messages (e.g: RoomInfo, TrackInfo, etc...)
 //    For this reason, info are only sent once, at creation (We're not using them for updates, we can infer them from
 //    events on the client implementation).
@@ -1443,61 +1436,64 @@ impl AudioSourceType {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FfiRequest {
-    #[prost(oneof="ffi_request::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22")]
+    #[prost(
+        oneof = "ffi_request::Message",
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22"
+    )]
     pub message: ::core::option::Option<ffi_request::Message>,
 }
 /// Nested message and enum types in `FfiRequest`.
 pub mod ffi_request {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Message {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Initialize(super::InitializeRequest),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Dispose(super::DisposeRequest),
         /// Room
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         Connect(super::ConnectRequest),
-        #[prost(message, tag="4")]
+        #[prost(message, tag = "4")]
         Disconnect(super::DisconnectRequest),
-        #[prost(message, tag="5")]
+        #[prost(message, tag = "5")]
         PublishTrack(super::PublishTrackRequest),
-        #[prost(message, tag="6")]
+        #[prost(message, tag = "6")]
         UnpublishTrack(super::UnpublishTrackRequest),
-        #[prost(message, tag="7")]
+        #[prost(message, tag = "7")]
         PublishData(super::PublishDataRequest),
-        #[prost(message, tag="8")]
+        #[prost(message, tag = "8")]
         SetSubscribed(super::SetSubscribedRequest),
         /// Track
-        #[prost(message, tag="9")]
+        #[prost(message, tag = "9")]
         CreateVideoTrack(super::CreateVideoTrackRequest),
-        #[prost(message, tag="10")]
+        #[prost(message, tag = "10")]
         CreateAudioTrack(super::CreateAudioTrackRequest),
         /// Video
-        #[prost(message, tag="11")]
+        #[prost(message, tag = "11")]
         AllocVideoBuffer(super::AllocVideoBufferRequest),
-        #[prost(message, tag="12")]
+        #[prost(message, tag = "12")]
         NewVideoStream(super::NewVideoStreamRequest),
-        #[prost(message, tag="13")]
+        #[prost(message, tag = "13")]
         NewVideoSource(super::NewVideoSourceRequest),
-        #[prost(message, tag="14")]
+        #[prost(message, tag = "14")]
         CaptureVideoFrame(super::CaptureVideoFrameRequest),
-        #[prost(message, tag="15")]
+        #[prost(message, tag = "15")]
         ToI420(super::ToI420Request),
-        #[prost(message, tag="16")]
+        #[prost(message, tag = "16")]
         ToArgb(super::ToArgbRequest),
         /// Audio
-        #[prost(message, tag="17")]
+        #[prost(message, tag = "17")]
         AllocAudioBuffer(super::AllocAudioBufferRequest),
-        #[prost(message, tag="18")]
+        #[prost(message, tag = "18")]
         NewAudioStream(super::NewAudioStreamRequest),
-        #[prost(message, tag="19")]
+        #[prost(message, tag = "19")]
         NewAudioSource(super::NewAudioSourceRequest),
-        #[prost(message, tag="20")]
+        #[prost(message, tag = "20")]
         CaptureAudioFrame(super::CaptureAudioFrameRequest),
-        #[prost(message, tag="21")]
+        #[prost(message, tag = "21")]
         NewAudioResampler(super::NewAudioResamplerRequest),
-        #[prost(message, tag="22")]
+        #[prost(message, tag = "22")]
         RemixAndResample(super::RemixAndResampleRequest),
     }
 }
@@ -1505,61 +1501,64 @@ pub mod ffi_request {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FfiResponse {
-    #[prost(oneof="ffi_response::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22")]
+    #[prost(
+        oneof = "ffi_response::Message",
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22"
+    )]
     pub message: ::core::option::Option<ffi_response::Message>,
 }
 /// Nested message and enum types in `FfiResponse`.
 pub mod ffi_response {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Message {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Initialize(super::InitializeResponse),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Dispose(super::DisposeResponse),
         /// Room
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         Connect(super::ConnectResponse),
-        #[prost(message, tag="4")]
+        #[prost(message, tag = "4")]
         Disconnect(super::DisconnectResponse),
-        #[prost(message, tag="5")]
+        #[prost(message, tag = "5")]
         PublishTrack(super::PublishTrackResponse),
-        #[prost(message, tag="6")]
+        #[prost(message, tag = "6")]
         UnpublishTrack(super::UnpublishTrackResponse),
-        #[prost(message, tag="7")]
+        #[prost(message, tag = "7")]
         PublishData(super::PublishDataResponse),
-        #[prost(message, tag="8")]
+        #[prost(message, tag = "8")]
         SetSubscribed(super::SetSubscribedResponse),
         /// Track
-        #[prost(message, tag="9")]
+        #[prost(message, tag = "9")]
         CreateVideoTrack(super::CreateVideoTrackResponse),
-        #[prost(message, tag="10")]
+        #[prost(message, tag = "10")]
         CreateAudioTrack(super::CreateAudioTrackResponse),
         /// Video
-        #[prost(message, tag="11")]
+        #[prost(message, tag = "11")]
         AllocVideoBuffer(super::AllocVideoBufferResponse),
-        #[prost(message, tag="12")]
+        #[prost(message, tag = "12")]
         NewVideoStream(super::NewVideoStreamResponse),
-        #[prost(message, tag="13")]
+        #[prost(message, tag = "13")]
         NewVideoSource(super::NewVideoSourceResponse),
-        #[prost(message, tag="14")]
+        #[prost(message, tag = "14")]
         CaptureVideoFrame(super::CaptureVideoFrameResponse),
-        #[prost(message, tag="15")]
+        #[prost(message, tag = "15")]
         ToI420(super::ToI420Response),
-        #[prost(message, tag="16")]
+        #[prost(message, tag = "16")]
         ToArgb(super::ToArgbResponse),
         /// Audio
-        #[prost(message, tag="17")]
+        #[prost(message, tag = "17")]
         AllocAudioBuffer(super::AllocAudioBufferResponse),
-        #[prost(message, tag="18")]
+        #[prost(message, tag = "18")]
         NewAudioStream(super::NewAudioStreamResponse),
-        #[prost(message, tag="19")]
+        #[prost(message, tag = "19")]
         NewAudioSource(super::NewAudioSourceResponse),
-        #[prost(message, tag="20")]
+        #[prost(message, tag = "20")]
         CaptureAudioFrame(super::CaptureAudioFrameResponse),
-        #[prost(message, tag="21")]
+        #[prost(message, tag = "21")]
         NewAudioResampler(super::NewAudioResamplerResponse),
-        #[prost(message, tag="22")]
+        #[prost(message, tag = "22")]
         RemixAndResample(super::RemixAndResampleResponse),
     }
 }
@@ -1569,31 +1568,31 @@ pub mod ffi_response {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FfiEvent {
-    #[prost(oneof="ffi_event::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9")]
+    #[prost(oneof = "ffi_event::Message", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9")]
     pub message: ::core::option::Option<ffi_event::Message>,
 }
 /// Nested message and enum types in `FfiEvent`.
 pub mod ffi_event {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Message {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         RoomEvent(super::RoomEvent),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         TrackEvent(super::TrackEvent),
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         VideoStreamEvent(super::VideoStreamEvent),
-        #[prost(message, tag="4")]
+        #[prost(message, tag = "4")]
         AudioStreamEvent(super::AudioStreamEvent),
-        #[prost(message, tag="5")]
+        #[prost(message, tag = "5")]
         Connect(super::ConnectCallback),
-        #[prost(message, tag="6")]
+        #[prost(message, tag = "6")]
         Disconnect(super::DisconnectCallback),
-        #[prost(message, tag="7")]
+        #[prost(message, tag = "7")]
         Dispose(super::DisposeCallback),
-        #[prost(message, tag="8")]
+        #[prost(message, tag = "8")]
         PublishTrack(super::PublishTrackCallback),
-        #[prost(message, tag="9")]
+        #[prost(message, tag = "9")]
         PublishData(super::PublishDataCallback),
     }
 }
@@ -1602,33 +1601,32 @@ pub mod ffi_event {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitializeRequest {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub event_callback_ptr: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InitializeResponse {
-}
+pub struct InitializeResponse {}
 /// Stop all rooms synchronously (Do we need async here?).
 /// e.g: This is used for the Unity Editor after each assemblies reload.
 /// TODO(theomonnom): Implement a debug mode where we can find all leaked handles?
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DisposeRequest {
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub r#async: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DisposeResponse {
     /// None if sync
-    #[prost(uint64, optional, tag="1")]
+    #[prost(uint64, optional, tag = "1")]
     pub async_id: ::core::option::Option<u64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DisposeCallback {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub async_id: u64,
 }
 // @@protoc_insertion_point(module)

--- a/livekit-ffi/src/proto.rs
+++ b/livekit-ffi/src/proto.rs
@@ -1,1 +1,4 @@
+#![allow(non_snake_case)]
+#![allow(clippy::enum_variant_names)]
+
 include!("livekit.proto.rs");

--- a/livekit-ffi/src/proto.rs
+++ b/livekit-ffi/src/proto.rs
@@ -1,0 +1,1 @@
+include!("livekit.proto.rs");

--- a/livekit-ffi/src/server/audio_source.rs
+++ b/livekit-ffi/src/server/audio_source.rs
@@ -29,7 +29,7 @@ impl FfiAudioSource {
         server: &'static server::FfiServer,
         new_source: proto::NewAudioSourceRequest,
     ) -> FfiResult<proto::AudioSourceInfo> {
-        let source_type = proto::AudioSourceType::from_i32(new_source.r#type).unwrap();
+        let source_type = new_source.r#type();
         #[allow(unreachable_patterns)]
         let source_inner = match source_type {
             #[cfg(not(target_arch = "wasm32"))]

--- a/livekit-ffi/src/server/audio_stream.rs
+++ b/livekit-ffi/src/server/audio_stream.rs
@@ -52,7 +52,7 @@ impl FfiAudioStream {
         };
 
         let (close_tx, close_rx) = oneshot::channel();
-        let stream_type = proto::AudioStreamType::from_i32(new_stream.r#type).unwrap();
+        let stream_type = new_stream.r#type();
         let audio_stream = match stream_type {
             #[cfg(not(target_arch = "wasm32"))]
             proto::AudioStreamType::AudioStreamNative => {

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -165,10 +165,10 @@ impl FfiServer {
         self.ffi_handles.insert(id, Box::new(handle));
     }
 
-    pub fn retrieve_handle<'a, T>(
-        &'a self,
+    pub fn retrieve_handle<T>(
+        &self,
         id: FfiHandleId,
-    ) -> FfiResult<MappedRef<'a, u64, Box<dyn FfiHandle>, T>>
+    ) -> FfiResult<MappedRef<'_, u64, Box<dyn FfiHandle>, T>>
     where
         T: FfiHandle,
     {

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -357,8 +357,7 @@ fn on_alloc_video_buffer(
     server: &'static FfiServer,
     alloc: proto::AllocVideoBufferRequest,
 ) -> FfiResult<proto::AllocVideoBufferResponse> {
-    let frame_type = proto::VideoFrameBufferType::from_i32(alloc.r#type).unwrap();
-    let buffer: BoxVideoFrameBuffer = match frame_type {
+    let buffer: BoxVideoFrameBuffer = match alloc.r#type() {
         proto::VideoFrameBufferType::I420 => Box::new(I420Buffer::new(alloc.width, alloc.height)),
         _ => {
             return Err(FfiError::InvalidRequest(
@@ -435,7 +434,7 @@ fn on_to_i420(
             let (sy, su, sv) = i420.strides();
             let (dy, du, dv) = i420.data_mut();
 
-            match proto::VideoFormatType::from_i32(info.format).unwrap() {
+            match info.format() {
                 proto::VideoFormatType::FormatArgb => {
                     yuv_helper::argb_to_i420(argb, info.stride, dy, sy, du, su, dv, sv, w, h)
                         .unwrap();
@@ -487,7 +486,7 @@ fn on_to_argb(
     let w = to_argb.dst_width as i32;
     let h = to_argb.dst_height as i32 * (if to_argb.flip_y { -1 } else { 1 });
 
-    let video_format = proto::VideoFormatType::from_i32(to_argb.dst_format).unwrap();
+    let video_format = to_argb.dst_format();
     buffer
         .to_argb(video_format.into(), argb, to_argb.dst_stride, w, h)
         .unwrap();

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -221,7 +221,7 @@ async fn forward_event(
             let handle_id = server.next_id();
             let ffi_participant = FfiParticipant {
                 handle: handle_id,
-                participant: Participant::Remote(participant.clone()),
+                participant: Participant::Remote(participant),
                 room: inner.clone(),
             };
             server.store_handle(handle_id, ffi_participant.clone());
@@ -247,7 +247,7 @@ async fn forward_event(
         } => {
             let ffi_publication = FfiPublication {
                 handle: server.next_id(),
-                publication: TrackPublication::Local(publication.clone()),
+                publication: TrackPublication::Local(publication),
             };
 
             let publication_info = proto::TrackPublicationInfo::from(
@@ -279,7 +279,7 @@ async fn forward_event(
         } => {
             let ffi_publication = FfiPublication {
                 handle: server.next_id(),
-                publication: TrackPublication::Remote(publication.clone()),
+                publication: TrackPublication::Remote(publication),
             };
 
             let publication_info = proto::TrackPublicationInfo::from(
@@ -314,7 +314,7 @@ async fn forward_event(
         } => {
             let ffi_track = FfiTrack {
                 handle: server.next_id(),
-                track: track.clone().into(),
+                track: track.into(),
             };
 
             let track_info = proto::TrackInfo::from(

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -143,7 +143,7 @@ impl RoomInner {
         let data = unsafe {
             slice::from_raw_parts(publish.data_ptr as *const u8, publish.data_len as usize)
         };
-        let kind = proto::DataPacketKind::from_i32(publish.kind).unwrap();
+        let kind = publish.kind();
         let destination_sids: Vec<String> = publish.destination_sids;
         let async_id = server.next_id();
 

--- a/livekit-ffi/src/server/video_source.rs
+++ b/livekit-ffi/src/server/video_source.rs
@@ -31,7 +31,7 @@ impl FfiVideoSource {
         server: &'static server::FfiServer,
         new_source: proto::NewVideoSourceRequest,
     ) -> FfiResult<proto::VideoSourceInfo> {
-        let source_type = proto::VideoSourceType::from_i32(new_source.r#type).unwrap();
+        let source_type = new_source.r#type();
         #[allow(unreachable_patterns)]
         let source_inner = match source_type {
             #[cfg(not(target_arch = "wasm32"))]
@@ -86,9 +86,8 @@ impl FfiVideoSource {
                     .downcast_ref::<BoxVideoFrameBuffer>()
                     .ok_or(FfiError::InvalidRequest("handle is not video frame".into()))?;
 
-                let rotation = proto::VideoRotation::from_i32(frame_info.rotation).unwrap();
                 let frame = VideoFrame {
-                    rotation: rotation.into(),
+                    rotation: frame_info.rotation().into(),
                     timestamp_us: frame_info.timestamp_us,
                     buffer,
                 };

--- a/livekit-ffi/src/server/video_stream.rs
+++ b/livekit-ffi/src/server/video_stream.rs
@@ -52,7 +52,7 @@ impl FfiVideoStream {
         };
 
         let (close_tx, close_rx) = oneshot::channel();
-        let stream_type = proto::VideoStreamType::from_i32(new_stream.r#type).unwrap();
+        let stream_type = new_stream.r#type();
         let stream = match stream_type {
             #[cfg(not(target_arch = "wasm32"))]
             proto::VideoStreamType::VideoStreamNative => {

--- a/livekit-protocol/src/lib.rs
+++ b/livekit-protocol/src/lib.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(non_snake_case)]
+#![allow(clippy::large_enum_variant)]
+
 pub mod debouncer;
 pub mod enum_dispatch;
-pub mod livekit;
 pub mod observer;
 
-pub use livekit::*;
+include!("livekit.rs");
 
 #[cfg(feature = "serde")]
 include!("livekit.serde.rs");

--- a/livekit-protocol/src/livekit.rs
+++ b/livekit-protocol/src/livekit.rs
@@ -1,104 +1,102 @@
-// Copyright 2023 LiveKit, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 // @generated
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Room {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub sid: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
-    #[prost(uint32, tag = "3")]
+    #[prost(uint32, tag="3")]
     pub empty_timeout: u32,
-    #[prost(uint32, tag = "4")]
+    #[prost(uint32, tag="4")]
     pub max_participants: u32,
-    #[prost(int64, tag = "5")]
+    #[prost(int64, tag="5")]
     pub creation_time: i64,
-    #[prost(string, tag = "6")]
+    #[prost(string, tag="6")]
     pub turn_password: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "7")]
+    #[prost(message, repeated, tag="7")]
     pub enabled_codecs: ::prost::alloc::vec::Vec<Codec>,
-    #[prost(string, tag = "8")]
+    #[prost(string, tag="8")]
     pub metadata: ::prost::alloc::string::String,
-    #[prost(uint32, tag = "9")]
+    #[prost(uint32, tag="9")]
     pub num_participants: u32,
-    #[prost(uint32, tag = "11")]
+    #[prost(uint32, tag="11")]
     pub num_publishers: u32,
-    #[prost(bool, tag = "10")]
+    #[prost(bool, tag="10")]
     pub active_recording: bool,
+    #[prost(message, optional, tag="12")]
+    pub playout_delay: ::core::option::Option<PlayoutDelay>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Codec {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub mime: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub fmtp_line: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PlayoutDelay {
+    #[prost(bool, tag="1")]
+    pub enabled: bool,
+    #[prost(uint32, tag="2")]
+    pub min: u32,
+    #[prost(uint32, tag="3")]
+    pub max: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ParticipantPermission {
     /// allow participant to subscribe to other tracks in the room
-    #[prost(bool, tag = "1")]
+    #[prost(bool, tag="1")]
     pub can_subscribe: bool,
     /// allow participant to publish new tracks to room
-    #[prost(bool, tag = "2")]
+    #[prost(bool, tag="2")]
     pub can_publish: bool,
     /// allow participant to publish data
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag="3")]
     pub can_publish_data: bool,
     /// sources that are allowed to be published
-    #[prost(enumeration = "TrackSource", repeated, tag = "9")]
+    #[prost(enumeration="TrackSource", repeated, tag="9")]
     pub can_publish_sources: ::prost::alloc::vec::Vec<i32>,
     /// indicates that it's hidden to others
-    #[prost(bool, tag = "7")]
+    #[prost(bool, tag="7")]
     pub hidden: bool,
     /// indicates it's a recorder instance
-    #[prost(bool, tag = "8")]
+    #[prost(bool, tag="8")]
     pub recorder: bool,
     /// indicates that participant can update own metadata
-    #[prost(bool, tag = "10")]
+    #[prost(bool, tag="10")]
     pub can_update_metadata: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ParticipantInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub sid: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub identity: ::prost::alloc::string::String,
-    #[prost(enumeration = "participant_info::State", tag = "3")]
+    #[prost(enumeration="participant_info::State", tag="3")]
     pub state: i32,
-    #[prost(message, repeated, tag = "4")]
+    #[prost(message, repeated, tag="4")]
     pub tracks: ::prost::alloc::vec::Vec<TrackInfo>,
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub metadata: ::prost::alloc::string::String,
     /// timestamp when participant joined room, in seconds
-    #[prost(int64, tag = "6")]
+    #[prost(int64, tag="6")]
     pub joined_at: i64,
-    #[prost(string, tag = "9")]
+    #[prost(string, tag="9")]
     pub name: ::prost::alloc::string::String,
-    #[prost(uint32, tag = "10")]
+    #[prost(uint32, tag="10")]
     pub version: u32,
-    #[prost(message, optional, tag = "11")]
+    #[prost(message, optional, tag="11")]
     pub permission: ::core::option::Option<ParticipantPermission>,
-    #[prost(string, tag = "12")]
+    #[prost(string, tag="12")]
     pub region: ::prost::alloc::string::String,
     /// indicates the participant has an active publisher connection
     /// and can publish to the server
-    #[prost(bool, tag = "13")]
+    #[prost(bool, tag="13")]
     pub is_publisher: bool,
 }
 /// Nested message and enum types in `ParticipantInfo`.
@@ -142,7 +140,8 @@ pub mod participant_info {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Encryption {}
+pub struct Encryption {
+}
 /// Nested message and enum types in `Encryption`.
 pub mod encryption {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -178,83 +177,85 @@ pub mod encryption {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SimulcastCodecInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub mime_type: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub mid: ::prost::alloc::string::String,
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub cid: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "4")]
+    #[prost(message, repeated, tag="4")]
     pub layers: ::prost::alloc::vec::Vec<VideoLayer>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub sid: ::prost::alloc::string::String,
-    #[prost(enumeration = "TrackType", tag = "2")]
+    #[prost(enumeration="TrackType", tag="2")]
     pub r#type: i32,
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub name: ::prost::alloc::string::String,
-    #[prost(bool, tag = "4")]
+    #[prost(bool, tag="4")]
     pub muted: bool,
     /// original width of video (unset for audio)
     /// clients may receive a lower resolution version with simulcast
-    #[prost(uint32, tag = "5")]
+    #[prost(uint32, tag="5")]
     pub width: u32,
     /// original height of video (unset for audio)
-    #[prost(uint32, tag = "6")]
+    #[prost(uint32, tag="6")]
     pub height: u32,
     /// true if track is simulcasted
-    #[prost(bool, tag = "7")]
+    #[prost(bool, tag="7")]
     pub simulcast: bool,
     /// true if DTX (Discontinuous Transmission) is disabled for audio
-    #[prost(bool, tag = "8")]
+    #[prost(bool, tag="8")]
     pub disable_dtx: bool,
     /// source of media
-    #[prost(enumeration = "TrackSource", tag = "9")]
+    #[prost(enumeration="TrackSource", tag="9")]
     pub source: i32,
-    #[prost(message, repeated, tag = "10")]
+    #[prost(message, repeated, tag="10")]
     pub layers: ::prost::alloc::vec::Vec<VideoLayer>,
     /// mime type of codec
-    #[prost(string, tag = "11")]
+    #[prost(string, tag="11")]
     pub mime_type: ::prost::alloc::string::String,
-    #[prost(string, tag = "12")]
+    #[prost(string, tag="12")]
     pub mid: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "13")]
+    #[prost(message, repeated, tag="13")]
     pub codecs: ::prost::alloc::vec::Vec<SimulcastCodecInfo>,
-    #[prost(bool, tag = "14")]
+    #[prost(bool, tag="14")]
     pub stereo: bool,
     /// true if RED (Redundant Encoding) is disabled for audio
-    #[prost(bool, tag = "15")]
+    #[prost(bool, tag="15")]
     pub disable_red: bool,
-    #[prost(enumeration = "encryption::Type", tag = "16")]
+    #[prost(enumeration="encryption::Type", tag="16")]
     pub encryption: i32,
+    #[prost(string, tag="17")]
+    pub stream: ::prost::alloc::string::String,
 }
 /// provide information about available spatial layers
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoLayer {
     /// for tracks with a single layer, this should be HIGH
-    #[prost(enumeration = "VideoQuality", tag = "1")]
+    #[prost(enumeration="VideoQuality", tag="1")]
     pub quality: i32,
-    #[prost(uint32, tag = "2")]
+    #[prost(uint32, tag="2")]
     pub width: u32,
-    #[prost(uint32, tag = "3")]
+    #[prost(uint32, tag="3")]
     pub height: u32,
     /// target bitrate in bit per second (bps), server will measure actual
-    #[prost(uint32, tag = "4")]
+    #[prost(uint32, tag="4")]
     pub bitrate: u32,
-    #[prost(uint32, tag = "5")]
+    #[prost(uint32, tag="5")]
     pub ssrc: u32,
 }
 /// new DataPacket API
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DataPacket {
-    #[prost(enumeration = "data_packet::Kind", tag = "1")]
+    #[prost(enumeration="data_packet::Kind", tag="1")]
     pub kind: i32,
-    #[prost(oneof = "data_packet::Value", tags = "2, 3")]
+    #[prost(oneof="data_packet::Value", tags="2, 3")]
     pub value: ::core::option::Option<data_packet::Value>,
 }
 /// Nested message and enum types in `DataPacket`.
@@ -286,73 +287,73 @@ pub mod data_packet {
         }
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
-        #[prost(message, tag = "2")]
+        #[prost(message, tag="2")]
         User(super::UserPacket),
-        #[prost(message, tag = "3")]
+        #[prost(message, tag="3")]
         Speaker(super::ActiveSpeakerUpdate),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ActiveSpeakerUpdate {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub speakers: ::prost::alloc::vec::Vec<SpeakerInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpeakerInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub sid: ::prost::alloc::string::String,
     /// audio level, 0-1.0, 1 is loudest
-    #[prost(float, tag = "2")]
+    #[prost(float, tag="2")]
     pub level: f32,
     /// true if speaker is currently active
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag="3")]
     pub active: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UserPacket {
     /// participant ID of user that sent the message
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub participant_sid: ::prost::alloc::string::String,
     /// user defined payload
-    #[prost(bytes = "vec", tag = "2")]
+    #[prost(bytes="vec", tag="2")]
     pub payload: ::prost::alloc::vec::Vec<u8>,
     /// the ID of the participants who will receive the message (the message will be sent to all the people in the room if this variable is empty)
-    #[prost(string, repeated, tag = "3")]
+    #[prost(string, repeated, tag="3")]
     pub destination_sids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// topic under which the message was published
-    #[prost(string, optional, tag = "4")]
+    #[prost(string, optional, tag="4")]
     pub topic: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ParticipantTracks {
     /// participant ID of participant to whom the tracks belong
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(string, repeated, tag = "2")]
+    #[prost(string, repeated, tag="2")]
     pub track_sids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// details about the server
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServerInfo {
-    #[prost(enumeration = "server_info::Edition", tag = "1")]
+    #[prost(enumeration="server_info::Edition", tag="1")]
     pub edition: i32,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub version: ::prost::alloc::string::String,
-    #[prost(int32, tag = "3")]
+    #[prost(int32, tag="3")]
     pub protocol: i32,
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub region: ::prost::alloc::string::String,
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub node_id: ::prost::alloc::string::String,
     /// additional debugging information. sent only if server is in development mode
-    #[prost(string, tag = "6")]
+    #[prost(string, tag="6")]
     pub debug_info: ::prost::alloc::string::String,
 }
 /// Nested message and enum types in `ServerInfo`.
@@ -388,26 +389,26 @@ pub mod server_info {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientInfo {
-    #[prost(enumeration = "client_info::Sdk", tag = "1")]
+    #[prost(enumeration="client_info::Sdk", tag="1")]
     pub sdk: i32,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub version: ::prost::alloc::string::String,
-    #[prost(int32, tag = "3")]
+    #[prost(int32, tag="3")]
     pub protocol: i32,
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub os: ::prost::alloc::string::String,
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub os_version: ::prost::alloc::string::String,
-    #[prost(string, tag = "6")]
+    #[prost(string, tag="6")]
     pub device_model: ::prost::alloc::string::String,
-    #[prost(string, tag = "7")]
+    #[prost(string, tag="7")]
     pub browser: ::prost::alloc::string::String,
-    #[prost(string, tag = "8")]
+    #[prost(string, tag="8")]
     pub browser_version: ::prost::alloc::string::String,
-    #[prost(string, tag = "9")]
+    #[prost(string, tag="9")]
     pub address: ::prost::alloc::string::String,
     /// wifi, wired, cellular, vpn, empty if not known
-    #[prost(string, tag = "10")]
+    #[prost(string, tag="10")]
     pub network: ::prost::alloc::string::String,
 }
 /// Nested message and enum types in `ClientInfo`.
@@ -464,130 +465,130 @@ pub mod client_info {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientConfiguration {
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag="1")]
     pub video: ::core::option::Option<VideoConfiguration>,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub screen: ::core::option::Option<VideoConfiguration>,
-    #[prost(enumeration = "ClientConfigSetting", tag = "3")]
+    #[prost(enumeration="ClientConfigSetting", tag="3")]
     pub resume_connection: i32,
-    #[prost(message, optional, tag = "4")]
+    #[prost(message, optional, tag="4")]
     pub disabled_codecs: ::core::option::Option<DisabledCodecs>,
-    #[prost(enumeration = "ClientConfigSetting", tag = "5")]
+    #[prost(enumeration="ClientConfigSetting", tag="5")]
     pub force_relay: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VideoConfiguration {
-    #[prost(enumeration = "ClientConfigSetting", tag = "1")]
+    #[prost(enumeration="ClientConfigSetting", tag="1")]
     pub hardware_encoder: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DisabledCodecs {
     /// disabled for both publish and subscribe
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub codecs: ::prost::alloc::vec::Vec<Codec>,
     /// only disable for publish
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag="2")]
     pub publish: ::prost::alloc::vec::Vec<Codec>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RtpStats {
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag="1")]
     pub start_time: ::core::option::Option<::pbjson_types::Timestamp>,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub end_time: ::core::option::Option<::pbjson_types::Timestamp>,
-    #[prost(double, tag = "3")]
+    #[prost(double, tag="3")]
     pub duration: f64,
-    #[prost(uint32, tag = "4")]
+    #[prost(uint32, tag="4")]
     pub packets: u32,
-    #[prost(double, tag = "5")]
+    #[prost(double, tag="5")]
     pub packet_rate: f64,
-    #[prost(uint64, tag = "6")]
+    #[prost(uint64, tag="6")]
     pub bytes: u64,
-    #[prost(uint64, tag = "39")]
+    #[prost(uint64, tag="39")]
     pub header_bytes: u64,
-    #[prost(double, tag = "7")]
+    #[prost(double, tag="7")]
     pub bitrate: f64,
-    #[prost(uint32, tag = "8")]
+    #[prost(uint32, tag="8")]
     pub packets_lost: u32,
-    #[prost(double, tag = "9")]
+    #[prost(double, tag="9")]
     pub packet_loss_rate: f64,
-    #[prost(float, tag = "10")]
+    #[prost(float, tag="10")]
     pub packet_loss_percentage: f32,
-    #[prost(uint32, tag = "11")]
+    #[prost(uint32, tag="11")]
     pub packets_duplicate: u32,
-    #[prost(double, tag = "12")]
+    #[prost(double, tag="12")]
     pub packet_duplicate_rate: f64,
-    #[prost(uint64, tag = "13")]
+    #[prost(uint64, tag="13")]
     pub bytes_duplicate: u64,
-    #[prost(uint64, tag = "40")]
+    #[prost(uint64, tag="40")]
     pub header_bytes_duplicate: u64,
-    #[prost(double, tag = "14")]
+    #[prost(double, tag="14")]
     pub bitrate_duplicate: f64,
-    #[prost(uint32, tag = "15")]
+    #[prost(uint32, tag="15")]
     pub packets_padding: u32,
-    #[prost(double, tag = "16")]
+    #[prost(double, tag="16")]
     pub packet_padding_rate: f64,
-    #[prost(uint64, tag = "17")]
+    #[prost(uint64, tag="17")]
     pub bytes_padding: u64,
-    #[prost(uint64, tag = "41")]
+    #[prost(uint64, tag="41")]
     pub header_bytes_padding: u64,
-    #[prost(double, tag = "18")]
+    #[prost(double, tag="18")]
     pub bitrate_padding: f64,
-    #[prost(uint32, tag = "19")]
+    #[prost(uint32, tag="19")]
     pub packets_out_of_order: u32,
-    #[prost(uint32, tag = "20")]
+    #[prost(uint32, tag="20")]
     pub frames: u32,
-    #[prost(double, tag = "21")]
+    #[prost(double, tag="21")]
     pub frame_rate: f64,
-    #[prost(double, tag = "22")]
+    #[prost(double, tag="22")]
     pub jitter_current: f64,
-    #[prost(double, tag = "23")]
+    #[prost(double, tag="23")]
     pub jitter_max: f64,
-    #[prost(map = "int32, uint32", tag = "24")]
+    #[prost(map="int32, uint32", tag="24")]
     pub gap_histogram: ::std::collections::HashMap<i32, u32>,
-    #[prost(uint32, tag = "25")]
+    #[prost(uint32, tag="25")]
     pub nacks: u32,
-    #[prost(uint32, tag = "37")]
+    #[prost(uint32, tag="37")]
     pub nack_acks: u32,
-    #[prost(uint32, tag = "26")]
+    #[prost(uint32, tag="26")]
     pub nack_misses: u32,
-    #[prost(uint32, tag = "38")]
+    #[prost(uint32, tag="38")]
     pub nack_repeated: u32,
-    #[prost(uint32, tag = "27")]
+    #[prost(uint32, tag="27")]
     pub plis: u32,
-    #[prost(message, optional, tag = "28")]
+    #[prost(message, optional, tag="28")]
     pub last_pli: ::core::option::Option<::pbjson_types::Timestamp>,
-    #[prost(uint32, tag = "29")]
+    #[prost(uint32, tag="29")]
     pub firs: u32,
-    #[prost(message, optional, tag = "30")]
+    #[prost(message, optional, tag="30")]
     pub last_fir: ::core::option::Option<::pbjson_types::Timestamp>,
-    #[prost(uint32, tag = "31")]
+    #[prost(uint32, tag="31")]
     pub rtt_current: u32,
-    #[prost(uint32, tag = "32")]
+    #[prost(uint32, tag="32")]
     pub rtt_max: u32,
-    #[prost(uint32, tag = "33")]
+    #[prost(uint32, tag="33")]
     pub key_frames: u32,
-    #[prost(message, optional, tag = "34")]
+    #[prost(message, optional, tag="34")]
     pub last_key_frame: ::core::option::Option<::pbjson_types::Timestamp>,
-    #[prost(uint32, tag = "35")]
+    #[prost(uint32, tag="35")]
     pub layer_lock_plis: u32,
-    #[prost(message, optional, tag = "36")]
+    #[prost(message, optional, tag="36")]
     pub last_layer_lock_pli: ::core::option::Option<::pbjson_types::Timestamp>,
-    #[prost(double, tag = "42")]
+    #[prost(double, tag="42")]
     pub sample_rate: f64,
     /// NEXT_ID: 44
-    #[prost(double, tag = "43")]
+    #[prost(double, tag="43")]
     pub drift_ms: f64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimedVersion {
-    #[prost(int64, tag = "1")]
+    #[prost(int64, tag="1")]
     pub unix_micro: i64,
-    #[prost(int32, tag = "2")]
+    #[prost(int32, tag="2")]
     pub ticks: i32,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -921,53 +922,53 @@ impl SubscriptionError {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RoomCompositeEgressRequest {
     /// required
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room_name: ::prost::alloc::string::String,
     /// (optional)
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub layout: ::prost::alloc::string::String,
     /// (default false)
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag="3")]
     pub audio_only: bool,
     /// (default false)
-    #[prost(bool, tag = "4")]
+    #[prost(bool, tag="4")]
     pub video_only: bool,
     /// template base url (default <https://recorder.livekit.io>)
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub custom_base_url: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "11")]
+    #[prost(message, repeated, tag="11")]
     pub file_outputs: ::prost::alloc::vec::Vec<EncodedFileOutput>,
-    #[prost(message, repeated, tag = "12")]
+    #[prost(message, repeated, tag="12")]
     pub stream_outputs: ::prost::alloc::vec::Vec<StreamOutput>,
-    #[prost(message, repeated, tag = "13")]
+    #[prost(message, repeated, tag="13")]
     pub segment_outputs: ::prost::alloc::vec::Vec<SegmentedFileOutput>,
     /// deprecated (use _output fields)
-    #[prost(oneof = "room_composite_egress_request::Output", tags = "6, 7, 10")]
+    #[prost(oneof="room_composite_egress_request::Output", tags="6, 7, 10")]
     pub output: ::core::option::Option<room_composite_egress_request::Output>,
-    #[prost(oneof = "room_composite_egress_request::Options", tags = "8, 9")]
+    #[prost(oneof="room_composite_egress_request::Options", tags="8, 9")]
     pub options: ::core::option::Option<room_composite_egress_request::Options>,
 }
 /// Nested message and enum types in `RoomCompositeEgressRequest`.
 pub mod room_composite_egress_request {
     /// deprecated (use _output fields)
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Output {
-        #[prost(message, tag = "6")]
+        #[prost(message, tag="6")]
         File(super::EncodedFileOutput),
-        #[prost(message, tag = "7")]
+        #[prost(message, tag="7")]
         Stream(super::StreamOutput),
-        #[prost(message, tag = "10")]
+        #[prost(message, tag="10")]
         Segments(super::SegmentedFileOutput),
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Options {
         /// (default H264_720P_30)
-        #[prost(enumeration = "super::EncodingOptionsPreset", tag = "8")]
+        #[prost(enumeration="super::EncodingOptionsPreset", tag="8")]
         Preset(i32),
         /// (optional)
-        #[prost(message, tag = "9")]
+        #[prost(message, tag="9")]
         Advanced(super::EncodingOptions),
     }
 }
@@ -975,45 +976,45 @@ pub mod room_composite_egress_request {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WebEgressRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub url: ::prost::alloc::string::String,
-    #[prost(bool, tag = "2")]
+    #[prost(bool, tag="2")]
     pub audio_only: bool,
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag="3")]
     pub video_only: bool,
-    #[prost(bool, tag = "12")]
+    #[prost(bool, tag="12")]
     pub await_start_signal: bool,
-    #[prost(message, repeated, tag = "9")]
+    #[prost(message, repeated, tag="9")]
     pub file_outputs: ::prost::alloc::vec::Vec<EncodedFileOutput>,
-    #[prost(message, repeated, tag = "10")]
+    #[prost(message, repeated, tag="10")]
     pub stream_outputs: ::prost::alloc::vec::Vec<StreamOutput>,
-    #[prost(message, repeated, tag = "11")]
+    #[prost(message, repeated, tag="11")]
     pub segment_outputs: ::prost::alloc::vec::Vec<SegmentedFileOutput>,
     /// deprecated (use _output fields)
-    #[prost(oneof = "web_egress_request::Output", tags = "4, 5, 6")]
+    #[prost(oneof="web_egress_request::Output", tags="4, 5, 6")]
     pub output: ::core::option::Option<web_egress_request::Output>,
-    #[prost(oneof = "web_egress_request::Options", tags = "7, 8")]
+    #[prost(oneof="web_egress_request::Options", tags="7, 8")]
     pub options: ::core::option::Option<web_egress_request::Options>,
 }
 /// Nested message and enum types in `WebEgressRequest`.
 pub mod web_egress_request {
     /// deprecated (use _output fields)
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Output {
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         File(super::EncodedFileOutput),
-        #[prost(message, tag = "5")]
+        #[prost(message, tag="5")]
         Stream(super::StreamOutput),
-        #[prost(message, tag = "6")]
+        #[prost(message, tag="6")]
         Segments(super::SegmentedFileOutput),
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Options {
-        #[prost(enumeration = "super::EncodingOptionsPreset", tag = "7")]
+        #[prost(enumeration="super::EncodingOptionsPreset", tag="7")]
         Preset(i32),
-        #[prost(message, tag = "8")]
+        #[prost(message, tag="8")]
         Advanced(super::EncodingOptions),
     }
 }
@@ -1022,47 +1023,47 @@ pub mod web_egress_request {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackCompositeEgressRequest {
     /// required
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room_name: ::prost::alloc::string::String,
     /// (optional)
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub audio_track_id: ::prost::alloc::string::String,
     /// (optional)
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub video_track_id: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "11")]
+    #[prost(message, repeated, tag="11")]
     pub file_outputs: ::prost::alloc::vec::Vec<EncodedFileOutput>,
-    #[prost(message, repeated, tag = "12")]
+    #[prost(message, repeated, tag="12")]
     pub stream_outputs: ::prost::alloc::vec::Vec<StreamOutput>,
-    #[prost(message, repeated, tag = "13")]
+    #[prost(message, repeated, tag="13")]
     pub segment_outputs: ::prost::alloc::vec::Vec<SegmentedFileOutput>,
     /// deprecated (use _output fields)
-    #[prost(oneof = "track_composite_egress_request::Output", tags = "4, 5, 8")]
+    #[prost(oneof="track_composite_egress_request::Output", tags="4, 5, 8")]
     pub output: ::core::option::Option<track_composite_egress_request::Output>,
-    #[prost(oneof = "track_composite_egress_request::Options", tags = "6, 7")]
+    #[prost(oneof="track_composite_egress_request::Options", tags="6, 7")]
     pub options: ::core::option::Option<track_composite_egress_request::Options>,
 }
 /// Nested message and enum types in `TrackCompositeEgressRequest`.
 pub mod track_composite_egress_request {
     /// deprecated (use _output fields)
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Output {
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         File(super::EncodedFileOutput),
-        #[prost(message, tag = "5")]
+        #[prost(message, tag="5")]
         Stream(super::StreamOutput),
-        #[prost(message, tag = "8")]
+        #[prost(message, tag="8")]
         Segments(super::SegmentedFileOutput),
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Options {
         /// (default H264_720P_30)
-        #[prost(enumeration = "super::EncodingOptionsPreset", tag = "6")]
+        #[prost(enumeration="super::EncodingOptionsPreset", tag="6")]
         Preset(i32),
         /// (optional)
-        #[prost(message, tag = "7")]
+        #[prost(message, tag="7")]
         Advanced(super::EncodingOptions),
     }
 }
@@ -1071,24 +1072,24 @@ pub mod track_composite_egress_request {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackEgressRequest {
     /// required
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room_name: ::prost::alloc::string::String,
     /// required
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub track_id: ::prost::alloc::string::String,
     /// required
-    #[prost(oneof = "track_egress_request::Output", tags = "3, 4")]
+    #[prost(oneof="track_egress_request::Output", tags="3, 4")]
     pub output: ::core::option::Option<track_egress_request::Output>,
 }
 /// Nested message and enum types in `TrackEgressRequest`.
 pub mod track_egress_request {
     /// required
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Output {
-        #[prost(message, tag = "3")]
+        #[prost(message, tag="3")]
         File(super::DirectFileOutput),
-        #[prost(string, tag = "4")]
+        #[prost(string, tag="4")]
         WebsocketUrl(::prost::alloc::string::String),
     }
 }
@@ -1096,29 +1097,29 @@ pub mod track_egress_request {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncodedFileOutput {
     /// (optional)
-    #[prost(enumeration = "EncodedFileType", tag = "1")]
+    #[prost(enumeration="EncodedFileType", tag="1")]
     pub file_type: i32,
     /// see egress docs for templating (default {room_name}-{time})
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub filepath: ::prost::alloc::string::String,
     /// disable upload of manifest file (default false)
-    #[prost(bool, tag = "6")]
+    #[prost(bool, tag="6")]
     pub disable_manifest: bool,
-    #[prost(oneof = "encoded_file_output::Output", tags = "3, 4, 5, 7")]
+    #[prost(oneof="encoded_file_output::Output", tags="3, 4, 5, 7")]
     pub output: ::core::option::Option<encoded_file_output::Output>,
 }
 /// Nested message and enum types in `EncodedFileOutput`.
 pub mod encoded_file_output {
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Output {
-        #[prost(message, tag = "3")]
+        #[prost(message, tag="3")]
         S3(super::S3Upload),
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         Gcp(super::GcpUpload),
-        #[prost(message, tag = "5")]
+        #[prost(message, tag="5")]
         Azure(super::AzureBlobUpload),
-        #[prost(message, tag = "7")]
+        #[prost(message, tag="7")]
         AliOss(super::AliOssUpload),
     }
 }
@@ -1127,40 +1128,40 @@ pub mod encoded_file_output {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SegmentedFileOutput {
     /// (optional)
-    #[prost(enumeration = "SegmentedFileProtocol", tag = "1")]
+    #[prost(enumeration="SegmentedFileProtocol", tag="1")]
     pub protocol: i32,
     /// (optional)
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub filename_prefix: ::prost::alloc::string::String,
     /// (optional)
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub playlist_name: ::prost::alloc::string::String,
     /// in seconds (optional)
-    #[prost(uint32, tag = "4")]
+    #[prost(uint32, tag="4")]
     pub segment_duration: u32,
     /// (optional, default INDEX)
-    #[prost(enumeration = "SegmentedFileSuffix", tag = "10")]
+    #[prost(enumeration="SegmentedFileSuffix", tag="10")]
     pub filename_suffix: i32,
     /// disable upload of manifest file (default false)
-    #[prost(bool, tag = "8")]
+    #[prost(bool, tag="8")]
     pub disable_manifest: bool,
     /// required
-    #[prost(oneof = "segmented_file_output::Output", tags = "5, 6, 7, 9")]
+    #[prost(oneof="segmented_file_output::Output", tags="5, 6, 7, 9")]
     pub output: ::core::option::Option<segmented_file_output::Output>,
 }
 /// Nested message and enum types in `SegmentedFileOutput`.
 pub mod segmented_file_output {
     /// required
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Output {
-        #[prost(message, tag = "5")]
+        #[prost(message, tag="5")]
         S3(super::S3Upload),
-        #[prost(message, tag = "6")]
+        #[prost(message, tag="6")]
         Gcp(super::GcpUpload),
-        #[prost(message, tag = "7")]
+        #[prost(message, tag="7")]
         Azure(super::AzureBlobUpload),
-        #[prost(message, tag = "9")]
+        #[prost(message, tag="9")]
         AliOss(super::AliOssUpload),
     }
 }
@@ -1168,246 +1169,245 @@ pub mod segmented_file_output {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DirectFileOutput {
     /// see egress docs for templating (default {track_id}-{time})
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub filepath: ::prost::alloc::string::String,
     /// disable upload of manifest file (default false)
-    #[prost(bool, tag = "5")]
+    #[prost(bool, tag="5")]
     pub disable_manifest: bool,
-    #[prost(oneof = "direct_file_output::Output", tags = "2, 3, 4, 6")]
+    #[prost(oneof="direct_file_output::Output", tags="2, 3, 4, 6")]
     pub output: ::core::option::Option<direct_file_output::Output>,
 }
 /// Nested message and enum types in `DirectFileOutput`.
 pub mod direct_file_output {
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Output {
-        #[prost(message, tag = "2")]
+        #[prost(message, tag="2")]
         S3(super::S3Upload),
-        #[prost(message, tag = "3")]
+        #[prost(message, tag="3")]
         Gcp(super::GcpUpload),
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         Azure(super::AzureBlobUpload),
-        #[prost(message, tag = "6")]
+        #[prost(message, tag="6")]
         AliOss(super::AliOssUpload),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct S3Upload {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub access_key: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub secret: ::prost::alloc::string::String,
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub region: ::prost::alloc::string::String,
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub endpoint: ::prost::alloc::string::String,
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub bucket: ::prost::alloc::string::String,
-    #[prost(bool, tag = "6")]
+    #[prost(bool, tag="6")]
     pub force_path_style: bool,
-    #[prost(map = "string, string", tag = "7")]
-    pub metadata:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    #[prost(string, tag = "8")]
+    #[prost(map="string, string", tag="7")]
+    pub metadata: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(string, tag="8")]
     pub tagging: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GcpUpload {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub credentials: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub bucket: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AzureBlobUpload {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub account_name: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub account_key: ::prost::alloc::string::String,
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub container_name: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AliOssUpload {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub access_key: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub secret: ::prost::alloc::string::String,
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub region: ::prost::alloc::string::String,
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub endpoint: ::prost::alloc::string::String,
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub bucket: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamOutput {
     /// required
-    #[prost(enumeration = "StreamProtocol", tag = "1")]
+    #[prost(enumeration="StreamProtocol", tag="1")]
     pub protocol: i32,
     /// required
-    #[prost(string, repeated, tag = "2")]
+    #[prost(string, repeated, tag="2")]
     pub urls: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncodingOptions {
     /// (default 1920)
-    #[prost(int32, tag = "1")]
+    #[prost(int32, tag="1")]
     pub width: i32,
     /// (default 1080)
-    #[prost(int32, tag = "2")]
+    #[prost(int32, tag="2")]
     pub height: i32,
     /// (default 24)
-    #[prost(int32, tag = "3")]
+    #[prost(int32, tag="3")]
     pub depth: i32,
     /// (default 30)
-    #[prost(int32, tag = "4")]
+    #[prost(int32, tag="4")]
     pub framerate: i32,
     /// (default OPUS)
-    #[prost(enumeration = "AudioCodec", tag = "5")]
+    #[prost(enumeration="AudioCodec", tag="5")]
     pub audio_codec: i32,
     /// (default 128)
-    #[prost(int32, tag = "6")]
+    #[prost(int32, tag="6")]
     pub audio_bitrate: i32,
     /// (default 44100)
-    #[prost(int32, tag = "7")]
+    #[prost(int32, tag="7")]
     pub audio_frequency: i32,
     /// (default H264_MAIN)
-    #[prost(enumeration = "VideoCodec", tag = "8")]
+    #[prost(enumeration="VideoCodec", tag="8")]
     pub video_codec: i32,
     /// (default 4500)
-    #[prost(int32, tag = "9")]
+    #[prost(int32, tag="9")]
     pub video_bitrate: i32,
     /// in seconds (default 4s for streaming, segment duration for segmented output, encoder default for files)
-    #[prost(double, tag = "10")]
+    #[prost(double, tag="10")]
     pub key_frame_interval: f64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateLayoutRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub egress_id: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub layout: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateStreamRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub egress_id: ::prost::alloc::string::String,
-    #[prost(string, repeated, tag = "2")]
+    #[prost(string, repeated, tag="2")]
     pub add_output_urls: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(string, repeated, tag = "3")]
+    #[prost(string, repeated, tag="3")]
     pub remove_output_urls: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListEgressRequest {
     /// (optional, filter by room name)
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room_name: ::prost::alloc::string::String,
     /// (optional, filter by egress ID)
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub egress_id: ::prost::alloc::string::String,
     /// (optional, list active egress only)
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag="3")]
     pub active: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListEgressResponse {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub items: ::prost::alloc::vec::Vec<EgressInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StopEgressRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub egress_id: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EgressInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub egress_id: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub room_id: ::prost::alloc::string::String,
-    #[prost(string, tag = "13")]
+    #[prost(string, tag="13")]
     pub room_name: ::prost::alloc::string::String,
-    #[prost(enumeration = "EgressStatus", tag = "3")]
+    #[prost(enumeration="EgressStatus", tag="3")]
     pub status: i32,
-    #[prost(int64, tag = "10")]
+    #[prost(int64, tag="10")]
     pub started_at: i64,
-    #[prost(int64, tag = "11")]
+    #[prost(int64, tag="11")]
     pub ended_at: i64,
-    #[prost(int64, tag = "18")]
+    #[prost(int64, tag="18")]
     pub updated_at: i64,
-    #[prost(string, tag = "9")]
+    #[prost(string, tag="9")]
     pub error: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "15")]
+    #[prost(message, repeated, tag="15")]
     pub stream_results: ::prost::alloc::vec::Vec<StreamInfo>,
-    #[prost(message, repeated, tag = "16")]
+    #[prost(message, repeated, tag="16")]
     pub file_results: ::prost::alloc::vec::Vec<FileInfo>,
-    #[prost(message, repeated, tag = "17")]
+    #[prost(message, repeated, tag="17")]
     pub segment_results: ::prost::alloc::vec::Vec<SegmentsInfo>,
-    #[prost(oneof = "egress_info::Request", tags = "4, 5, 6, 14")]
+    #[prost(oneof="egress_info::Request", tags="4, 5, 6, 14")]
     pub request: ::core::option::Option<egress_info::Request>,
     /// deprecated (use _result fields)
-    #[prost(oneof = "egress_info::Result", tags = "7, 8, 12")]
+    #[prost(oneof="egress_info::Result", tags="7, 8, 12")]
     pub result: ::core::option::Option<egress_info::Result>,
 }
 /// Nested message and enum types in `EgressInfo`.
 pub mod egress_info {
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Request {
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         RoomComposite(super::RoomCompositeEgressRequest),
-        #[prost(message, tag = "5")]
+        #[prost(message, tag="5")]
         TrackComposite(super::TrackCompositeEgressRequest),
-        #[prost(message, tag = "6")]
+        #[prost(message, tag="6")]
         Track(super::TrackEgressRequest),
-        #[prost(message, tag = "14")]
+        #[prost(message, tag="14")]
         Web(super::WebEgressRequest),
     }
     /// deprecated (use _result fields)
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Result {
-        #[prost(message, tag = "7")]
+        #[prost(message, tag="7")]
         Stream(super::StreamInfoList),
-        #[prost(message, tag = "8")]
+        #[prost(message, tag="8")]
         File(super::FileInfo),
-        #[prost(message, tag = "12")]
+        #[prost(message, tag="12")]
         Segments(super::SegmentsInfo),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamInfoList {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub info: ::prost::alloc::vec::Vec<StreamInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub url: ::prost::alloc::string::String,
-    #[prost(int64, tag = "2")]
+    #[prost(int64, tag="2")]
     pub started_at: i64,
-    #[prost(int64, tag = "3")]
+    #[prost(int64, tag="3")]
     pub ended_at: i64,
-    #[prost(int64, tag = "4")]
+    #[prost(int64, tag="4")]
     pub duration: i64,
-    #[prost(enumeration = "stream_info::Status", tag = "5")]
+    #[prost(enumeration="stream_info::Status", tag="5")]
     pub status: i32,
-    #[prost(string, tag = "6")]
+    #[prost(string, tag="6")]
     pub error: ::prost::alloc::string::String,
 }
 /// Nested message and enum types in `StreamInfo`.
@@ -1445,59 +1445,59 @@ pub mod stream_info {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub filename: ::prost::alloc::string::String,
-    #[prost(int64, tag = "2")]
+    #[prost(int64, tag="2")]
     pub started_at: i64,
-    #[prost(int64, tag = "3")]
+    #[prost(int64, tag="3")]
     pub ended_at: i64,
-    #[prost(int64, tag = "6")]
+    #[prost(int64, tag="6")]
     pub duration: i64,
-    #[prost(int64, tag = "4")]
+    #[prost(int64, tag="4")]
     pub size: i64,
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub location: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SegmentsInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub playlist_name: ::prost::alloc::string::String,
-    #[prost(int64, tag = "2")]
+    #[prost(int64, tag="2")]
     pub duration: i64,
-    #[prost(int64, tag = "3")]
+    #[prost(int64, tag="3")]
     pub size: i64,
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub playlist_location: ::prost::alloc::string::String,
-    #[prost(int64, tag = "5")]
+    #[prost(int64, tag="5")]
     pub segment_count: i64,
-    #[prost(int64, tag = "6")]
+    #[prost(int64, tag="6")]
     pub started_at: i64,
-    #[prost(int64, tag = "7")]
+    #[prost(int64, tag="7")]
     pub ended_at: i64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AutoTrackEgress {
     /// see docs for templating (default {track_id}-{time})
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub filepath: ::prost::alloc::string::String,
     /// disables upload of json manifest file (default false)
-    #[prost(bool, tag = "5")]
+    #[prost(bool, tag="5")]
     pub disable_manifest: bool,
-    #[prost(oneof = "auto_track_egress::Output", tags = "2, 3, 4")]
+    #[prost(oneof="auto_track_egress::Output", tags="2, 3, 4")]
     pub output: ::core::option::Option<auto_track_egress::Output>,
 }
 /// Nested message and enum types in `AutoTrackEgress`.
 pub mod auto_track_egress {
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Output {
-        #[prost(message, tag = "2")]
+        #[prost(message, tag="2")]
         S3(super::S3Upload),
-        #[prost(message, tag = "3")]
+        #[prost(message, tag="3")]
         Gcp(super::GcpUpload),
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         Azure(super::AzureBlobUpload),
     }
 }
@@ -1544,9 +1544,7 @@ impl SegmentedFileProtocol {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            SegmentedFileProtocol::DefaultSegmentedFileProtocol => {
-                "DEFAULT_SEGMENTED_FILE_PROTOCOL"
-            }
+            SegmentedFileProtocol::DefaultSegmentedFileProtocol => "DEFAULT_SEGMENTED_FILE_PROTOCOL",
             SegmentedFileProtocol::HlsProtocol => "HLS_PROTOCOL",
         }
     }
@@ -1708,307 +1706,305 @@ impl EgressStatus {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignalRequest {
-    #[prost(
-        oneof = "signal_request::Message",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16"
-    )]
+    #[prost(oneof="signal_request::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16")]
     pub message: ::core::option::Option<signal_request::Message>,
 }
 /// Nested message and enum types in `SignalRequest`.
 pub mod signal_request {
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Message {
         /// initial join exchange, for publisher
-        #[prost(message, tag = "1")]
+        #[prost(message, tag="1")]
         Offer(super::SessionDescription),
         /// participant answering publisher offer
-        #[prost(message, tag = "2")]
+        #[prost(message, tag="2")]
         Answer(super::SessionDescription),
-        #[prost(message, tag = "3")]
+        #[prost(message, tag="3")]
         Trickle(super::TrickleRequest),
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         AddTrack(super::AddTrackRequest),
         /// mute the participant's published tracks
-        #[prost(message, tag = "5")]
+        #[prost(message, tag="5")]
         Mute(super::MuteTrackRequest),
         /// Subscribe or unsubscribe from tracks
-        #[prost(message, tag = "6")]
+        #[prost(message, tag="6")]
         Subscription(super::UpdateSubscription),
         /// Update settings of subscribed tracks
-        #[prost(message, tag = "7")]
+        #[prost(message, tag="7")]
         TrackSetting(super::UpdateTrackSettings),
         /// Immediately terminate session
-        #[prost(message, tag = "8")]
+        #[prost(message, tag="8")]
         Leave(super::LeaveRequest),
         /// Update published video layers
-        #[prost(message, tag = "10")]
+        #[prost(message, tag="10")]
         UpdateLayers(super::UpdateVideoLayers),
         /// Update subscriber permissions
-        #[prost(message, tag = "11")]
+        #[prost(message, tag="11")]
         SubscriptionPermission(super::SubscriptionPermission),
         /// sync client's subscribe state to server during reconnect
-        #[prost(message, tag = "12")]
+        #[prost(message, tag="12")]
         SyncState(super::SyncState),
         /// Simulate conditions, for client validations
-        #[prost(message, tag = "13")]
+        #[prost(message, tag="13")]
         Simulate(super::SimulateScenario),
         /// client triggered ping to server
         ///
         /// deprecated by ping_req (message Ping)
-        #[prost(int64, tag = "14")]
+        #[prost(int64, tag="14")]
         Ping(i64),
         /// update a participant's own metadata and/or name
-        #[prost(message, tag = "15")]
+        #[prost(message, tag="15")]
         UpdateMetadata(super::UpdateParticipantMetadata),
-        #[prost(message, tag = "16")]
+        #[prost(message, tag="16")]
         PingReq(super::Ping),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignalResponse {
-    #[prost(
-        oneof = "signal_response::Message",
-        tags = "1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21"
-    )]
+    #[prost(oneof="signal_response::Message", tags="1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21")]
     pub message: ::core::option::Option<signal_response::Message>,
 }
 /// Nested message and enum types in `SignalResponse`.
 pub mod signal_response {
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Message {
         /// sent when join is accepted
-        #[prost(message, tag = "1")]
+        #[prost(message, tag="1")]
         Join(super::JoinResponse),
         /// sent when server answers publisher
-        #[prost(message, tag = "2")]
+        #[prost(message, tag="2")]
         Answer(super::SessionDescription),
         /// sent when server is sending subscriber an offer
-        #[prost(message, tag = "3")]
+        #[prost(message, tag="3")]
         Offer(super::SessionDescription),
         /// sent when an ICE candidate is available
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         Trickle(super::TrickleRequest),
         /// sent when participants in the room has changed
-        #[prost(message, tag = "5")]
+        #[prost(message, tag="5")]
         Update(super::ParticipantUpdate),
         /// sent to the participant when their track has been published
-        #[prost(message, tag = "6")]
+        #[prost(message, tag="6")]
         TrackPublished(super::TrackPublishedResponse),
         /// Immediately terminate session
-        #[prost(message, tag = "8")]
+        #[prost(message, tag="8")]
         Leave(super::LeaveRequest),
         /// server initiated mute
-        #[prost(message, tag = "9")]
+        #[prost(message, tag="9")]
         Mute(super::MuteTrackRequest),
         /// indicates changes to speaker status, including when they've gone to not speaking
-        #[prost(message, tag = "10")]
+        #[prost(message, tag="10")]
         SpeakersChanged(super::SpeakersChanged),
         /// sent when metadata of the room has changed
-        #[prost(message, tag = "11")]
+        #[prost(message, tag="11")]
         RoomUpdate(super::RoomUpdate),
         /// when connection quality changed
-        #[prost(message, tag = "12")]
+        #[prost(message, tag="12")]
         ConnectionQuality(super::ConnectionQualityUpdate),
         /// when streamed tracks state changed, used to notify when any of the streams were paused due to
         /// congestion
-        #[prost(message, tag = "13")]
+        #[prost(message, tag="13")]
         StreamStateUpdate(super::StreamStateUpdate),
         /// when max subscribe quality changed, used by dynamic broadcasting to disable unused layers
-        #[prost(message, tag = "14")]
+        #[prost(message, tag="14")]
         SubscribedQualityUpdate(super::SubscribedQualityUpdate),
         /// when subscription permission changed
-        #[prost(message, tag = "15")]
+        #[prost(message, tag="15")]
         SubscriptionPermissionUpdate(super::SubscriptionPermissionUpdate),
         /// update the token the client was using, to prevent an active client from using an expired token
-        #[prost(string, tag = "16")]
+        #[prost(string, tag="16")]
         RefreshToken(::prost::alloc::string::String),
         /// server initiated track unpublish
-        #[prost(message, tag = "17")]
+        #[prost(message, tag="17")]
         TrackUnpublished(super::TrackUnpublishedResponse),
         /// respond to ping
         ///
         /// deprecated by pong_resp (message Pong)
-        #[prost(int64, tag = "18")]
+        #[prost(int64, tag="18")]
         Pong(i64),
         /// sent when client reconnects
-        #[prost(message, tag = "19")]
+        #[prost(message, tag="19")]
         Reconnect(super::ReconnectResponse),
         /// respond to Ping
-        #[prost(message, tag = "20")]
+        #[prost(message, tag="20")]
         PongResp(super::Pong),
         /// Subscription response, client should not expect any media from this subscription if it fails
-        #[prost(message, tag = "21")]
+        #[prost(message, tag="21")]
         SubscriptionResponse(super::SubscriptionResponse),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SimulcastCodec {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub codec: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub cid: ::prost::alloc::string::String,
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag="3")]
     pub enable_simulcast_layers: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddTrackRequest {
     /// client ID of track, to match it when RTC track is received
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub cid: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
-    #[prost(enumeration = "TrackType", tag = "3")]
+    #[prost(enumeration="TrackType", tag="3")]
     pub r#type: i32,
     /// to be deprecated in favor of layers
-    #[prost(uint32, tag = "4")]
+    #[prost(uint32, tag="4")]
     pub width: u32,
-    #[prost(uint32, tag = "5")]
+    #[prost(uint32, tag="5")]
     pub height: u32,
     /// true to add track and initialize to muted
-    #[prost(bool, tag = "6")]
+    #[prost(bool, tag="6")]
     pub muted: bool,
     /// true if DTX (Discontinuous Transmission) is disabled for audio
-    #[prost(bool, tag = "7")]
+    #[prost(bool, tag="7")]
     pub disable_dtx: bool,
-    #[prost(enumeration = "TrackSource", tag = "8")]
+    #[prost(enumeration="TrackSource", tag="8")]
     pub source: i32,
-    #[prost(message, repeated, tag = "9")]
+    #[prost(message, repeated, tag="9")]
     pub layers: ::prost::alloc::vec::Vec<VideoLayer>,
-    #[prost(message, repeated, tag = "10")]
+    #[prost(message, repeated, tag="10")]
     pub simulcast_codecs: ::prost::alloc::vec::Vec<SimulcastCodec>,
     /// server ID of track, publish new codec to exist track
-    #[prost(string, tag = "11")]
+    #[prost(string, tag="11")]
     pub sid: ::prost::alloc::string::String,
-    #[prost(bool, tag = "12")]
+    #[prost(bool, tag="12")]
     pub stereo: bool,
     /// true if RED (Redundant Encoding) is disabled for audio
-    #[prost(bool, tag = "13")]
+    #[prost(bool, tag="13")]
     pub disable_red: bool,
-    #[prost(enumeration = "encryption::Type", tag = "14")]
+    #[prost(enumeration="encryption::Type", tag="14")]
     pub encryption: i32,
+    /// which stream the track belongs to, used to group tracks together.
+    /// if not specified, server will infer it from track source to bundle camera/microphone, screenshare/audio together
+    #[prost(string, tag="15")]
+    pub stream: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrickleRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub candidate_init: ::prost::alloc::string::String,
-    #[prost(enumeration = "SignalTarget", tag = "2")]
+    #[prost(enumeration="SignalTarget", tag="2")]
     pub target: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MuteTrackRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub sid: ::prost::alloc::string::String,
-    #[prost(bool, tag = "2")]
+    #[prost(bool, tag="2")]
     pub muted: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct JoinResponse {
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag="1")]
     pub room: ::core::option::Option<Room>,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub participant: ::core::option::Option<ParticipantInfo>,
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub other_participants: ::prost::alloc::vec::Vec<ParticipantInfo>,
     /// deprecated. use server_info.version instead.
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub server_version: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "5")]
+    #[prost(message, repeated, tag="5")]
     pub ice_servers: ::prost::alloc::vec::Vec<IceServer>,
     /// use subscriber as the primary PeerConnection
-    #[prost(bool, tag = "6")]
+    #[prost(bool, tag="6")]
     pub subscriber_primary: bool,
     /// when the current server isn't available, return alternate url to retry connection
     /// when this is set, the other fields will be largely empty
-    #[prost(string, tag = "7")]
+    #[prost(string, tag="7")]
     pub alternative_url: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "8")]
+    #[prost(message, optional, tag="8")]
     pub client_configuration: ::core::option::Option<ClientConfiguration>,
     /// deprecated. use server_info.region instead.
-    #[prost(string, tag = "9")]
+    #[prost(string, tag="9")]
     pub server_region: ::prost::alloc::string::String,
-    #[prost(int32, tag = "10")]
+    #[prost(int32, tag="10")]
     pub ping_timeout: i32,
-    #[prost(int32, tag = "11")]
+    #[prost(int32, tag="11")]
     pub ping_interval: i32,
-    #[prost(message, optional, tag = "12")]
+    #[prost(message, optional, tag="12")]
     pub server_info: ::core::option::Option<ServerInfo>,
     /// Server-Injected-Frame byte trailer, used to identify unencrypted frames when e2ee is enabled
-    #[prost(bytes = "vec", tag = "13")]
+    #[prost(bytes="vec", tag="13")]
     pub sif_trailer: ::prost::alloc::vec::Vec<u8>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReconnectResponse {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub ice_servers: ::prost::alloc::vec::Vec<IceServer>,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub client_configuration: ::core::option::Option<ClientConfiguration>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackPublishedResponse {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub cid: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub track: ::core::option::Option<TrackInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackUnpublishedResponse {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub track_sid: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SessionDescription {
     /// "answer" | "offer" | "pranswer" | "rollback"
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub r#type: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub sdp: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ParticipantUpdate {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub participants: ::prost::alloc::vec::Vec<ParticipantInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateSubscription {
-    #[prost(string, repeated, tag = "1")]
+    #[prost(string, repeated, tag="1")]
     pub track_sids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(bool, tag = "2")]
+    #[prost(bool, tag="2")]
     pub subscribe: bool,
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub participant_tracks: ::prost::alloc::vec::Vec<ParticipantTracks>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateTrackSettings {
-    #[prost(string, repeated, tag = "1")]
+    #[prost(string, repeated, tag="1")]
     pub track_sids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// when true, the track is placed in a paused state, with no new data returned
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag="3")]
     pub disabled: bool,
     /// deprecated in favor of width & height
-    #[prost(enumeration = "VideoQuality", tag = "4")]
+    #[prost(enumeration="VideoQuality", tag="4")]
     pub quality: i32,
     /// for video, width to receive
-    #[prost(uint32, tag = "5")]
+    #[prost(uint32, tag="5")]
     pub width: u32,
     /// for video, height to receive
-    #[prost(uint32, tag = "6")]
+    #[prost(uint32, tag="6")]
     pub height: u32,
-    #[prost(uint32, tag = "7")]
+    #[prost(uint32, tag="7")]
     pub fps: u32,
     /// subscription priority. 1 being the highest (0 is unset)
     /// when unset, server sill assign priority based on the order of subscription
@@ -2017,7 +2013,7 @@ pub struct UpdateTrackSettings {
     ///     pause the lowest priority tracks
     /// 2. when the network is congested, server will assign available bandwidth to
     ///     higher priority tracks first. lowest priority tracks can be paused
-    #[prost(uint32, tag = "8")]
+    #[prost(uint32, tag="8")]
     pub priority: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2025,237 +2021,237 @@ pub struct UpdateTrackSettings {
 pub struct LeaveRequest {
     /// sent when server initiates the disconnect due to server-restart
     /// indicates clients should attempt full-reconnect sequence
-    #[prost(bool, tag = "1")]
+    #[prost(bool, tag="1")]
     pub can_reconnect: bool,
-    #[prost(enumeration = "DisconnectReason", tag = "2")]
+    #[prost(enumeration="DisconnectReason", tag="2")]
     pub reason: i32,
 }
 /// message to indicate published video track dimensions are changing
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateVideoLayers {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub track_sid: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag="2")]
     pub layers: ::prost::alloc::vec::Vec<VideoLayer>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateParticipantMetadata {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub metadata: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IceServer {
-    #[prost(string, repeated, tag = "1")]
+    #[prost(string, repeated, tag="1")]
     pub urls: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub username: ::prost::alloc::string::String,
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub credential: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpeakersChanged {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub speakers: ::prost::alloc::vec::Vec<SpeakerInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RoomUpdate {
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag="1")]
     pub room: ::core::option::Option<Room>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectionQualityInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(enumeration = "ConnectionQuality", tag = "2")]
+    #[prost(enumeration="ConnectionQuality", tag="2")]
     pub quality: i32,
-    #[prost(float, tag = "3")]
+    #[prost(float, tag="3")]
     pub score: f32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectionQualityUpdate {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub updates: ::prost::alloc::vec::Vec<ConnectionQualityInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamStateInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub track_sid: ::prost::alloc::string::String,
-    #[prost(enumeration = "StreamState", tag = "3")]
+    #[prost(enumeration="StreamState", tag="3")]
     pub state: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamStateUpdate {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub stream_states: ::prost::alloc::vec::Vec<StreamStateInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SubscribedQuality {
-    #[prost(enumeration = "VideoQuality", tag = "1")]
+    #[prost(enumeration="VideoQuality", tag="1")]
     pub quality: i32,
-    #[prost(bool, tag = "2")]
+    #[prost(bool, tag="2")]
     pub enabled: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SubscribedCodec {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub codec: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag="2")]
     pub qualities: ::prost::alloc::vec::Vec<SubscribedQuality>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SubscribedQualityUpdate {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub track_sid: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag="2")]
     pub subscribed_qualities: ::prost::alloc::vec::Vec<SubscribedQuality>,
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub subscribed_codecs: ::prost::alloc::vec::Vec<SubscribedCodec>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TrackPermission {
     /// permission could be granted either by participant sid or identity
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(bool, tag = "2")]
+    #[prost(bool, tag="2")]
     pub all_tracks: bool,
-    #[prost(string, repeated, tag = "3")]
+    #[prost(string, repeated, tag="3")]
     pub track_sids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub participant_identity: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SubscriptionPermission {
-    #[prost(bool, tag = "1")]
+    #[prost(bool, tag="1")]
     pub all_participants: bool,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag="2")]
     pub track_permissions: ::prost::alloc::vec::Vec<TrackPermission>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SubscriptionPermissionUpdate {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub participant_sid: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub track_sid: ::prost::alloc::string::String,
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag="3")]
     pub allowed: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncState {
     /// last subscribe answer before reconnecting
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag="1")]
     pub answer: ::core::option::Option<SessionDescription>,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub subscription: ::core::option::Option<UpdateSubscription>,
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub publish_tracks: ::prost::alloc::vec::Vec<TrackPublishedResponse>,
-    #[prost(message, repeated, tag = "4")]
+    #[prost(message, repeated, tag="4")]
     pub data_channels: ::prost::alloc::vec::Vec<DataChannelInfo>,
     /// last received server side offer before reconnecting
-    #[prost(message, optional, tag = "5")]
+    #[prost(message, optional, tag="5")]
     pub offer: ::core::option::Option<SessionDescription>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DataChannelInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub label: ::prost::alloc::string::String,
-    #[prost(uint32, tag = "2")]
+    #[prost(uint32, tag="2")]
     pub id: u32,
-    #[prost(enumeration = "SignalTarget", tag = "3")]
+    #[prost(enumeration="SignalTarget", tag="3")]
     pub target: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SimulateScenario {
-    #[prost(oneof = "simulate_scenario::Scenario", tags = "1, 2, 3, 4, 5, 6")]
+    #[prost(oneof="simulate_scenario::Scenario", tags="1, 2, 3, 4, 5, 6")]
     pub scenario: ::core::option::Option<simulate_scenario::Scenario>,
 }
 /// Nested message and enum types in `SimulateScenario`.
 pub mod simulate_scenario {
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Scenario {
         /// simulate N seconds of speaker activity
-        #[prost(int32, tag = "1")]
+        #[prost(int32, tag="1")]
         SpeakerUpdate(i32),
         /// simulate local node failure
-        #[prost(bool, tag = "2")]
+        #[prost(bool, tag="2")]
         NodeFailure(bool),
         /// simulate migration
-        #[prost(bool, tag = "3")]
+        #[prost(bool, tag="3")]
         Migration(bool),
         /// server to send leave
-        #[prost(bool, tag = "4")]
+        #[prost(bool, tag="4")]
         ServerLeave(bool),
         /// switch candidate protocol to tcp
-        #[prost(enumeration = "super::CandidateProtocol", tag = "5")]
+        #[prost(enumeration="super::CandidateProtocol", tag="5")]
         SwitchCandidateProtocol(i32),
         /// maximum bandwidth for subscribers, in bps
         /// when zero, clears artificial bandwidth limit
-        #[prost(int64, tag = "6")]
+        #[prost(int64, tag="6")]
         SubscriberBandwidth(i64),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Ping {
-    #[prost(int64, tag = "1")]
+    #[prost(int64, tag="1")]
     pub timestamp: i64,
     /// rtt in milliseconds calculated by client
-    #[prost(int64, tag = "2")]
+    #[prost(int64, tag="2")]
     pub rtt: i64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Pong {
     /// timestamp field of last received ping request
-    #[prost(int64, tag = "1")]
+    #[prost(int64, tag="1")]
     pub last_ping_timestamp: i64,
-    #[prost(int64, tag = "2")]
+    #[prost(int64, tag="2")]
     pub timestamp: i64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegionSettings {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub regions: ::prost::alloc::vec::Vec<RegionInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegionInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub region: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub url: ::prost::alloc::string::String,
-    #[prost(int64, tag = "3")]
+    #[prost(int64, tag="3")]
     pub distance: i64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SubscriptionResponse {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub track_sid: ::prost::alloc::string::String,
-    #[prost(enumeration = "SubscriptionError", tag = "2")]
+    #[prost(enumeration="SubscriptionError", tag="2")]
     pub err: i32,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -2343,231 +2339,235 @@ impl CandidateProtocol {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateRoomRequest {
     /// name of the room
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
     /// number of seconds to keep the room open if no one joins
-    #[prost(uint32, tag = "2")]
+    #[prost(uint32, tag="2")]
     pub empty_timeout: u32,
     /// limit number of participants that can be in a room
-    #[prost(uint32, tag = "3")]
+    #[prost(uint32, tag="3")]
     pub max_participants: u32,
     /// override the node room is allocated to, for debugging
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub node_id: ::prost::alloc::string::String,
     /// metadata of room
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub metadata: ::prost::alloc::string::String,
     /// egress
-    #[prost(message, optional, tag = "6")]
+    #[prost(message, optional, tag="6")]
     pub egress: ::core::option::Option<RoomEgress>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RoomEgress {
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag="1")]
     pub room: ::core::option::Option<RoomCompositeEgressRequest>,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub tracks: ::core::option::Option<AutoTrackEgress>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListRoomsRequest {
     /// when set, will only return rooms with name match
-    #[prost(string, repeated, tag = "1")]
+    #[prost(string, repeated, tag="1")]
     pub names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListRoomsResponse {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub rooms: ::prost::alloc::vec::Vec<Room>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteRoomRequest {
     /// name of the room
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteRoomResponse {}
+pub struct DeleteRoomResponse {
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListParticipantsRequest {
     /// name of the room
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListParticipantsResponse {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub participants: ::prost::alloc::vec::Vec<ParticipantInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RoomParticipantIdentity {
     /// name of the room
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room: ::prost::alloc::string::String,
     /// identity of the participant
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub identity: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RemoveParticipantResponse {}
+pub struct RemoveParticipantResponse {
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MuteRoomTrackRequest {
     /// name of the room
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub identity: ::prost::alloc::string::String,
     /// sid of the track to mute
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub track_sid: ::prost::alloc::string::String,
     /// set to true to mute, false to unmute
-    #[prost(bool, tag = "4")]
+    #[prost(bool, tag="4")]
     pub muted: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MuteRoomTrackResponse {
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag="1")]
     pub track: ::core::option::Option<TrackInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateParticipantRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub identity: ::prost::alloc::string::String,
     /// metadata to update. skipping updates if left empty
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub metadata: ::prost::alloc::string::String,
     /// set to update the participant's permissions
-    #[prost(message, optional, tag = "4")]
+    #[prost(message, optional, tag="4")]
     pub permission: ::core::option::Option<ParticipantPermission>,
     /// display name to update
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub name: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateSubscriptionsRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub identity: ::prost::alloc::string::String,
     /// list of sids of tracks
-    #[prost(string, repeated, tag = "3")]
+    #[prost(string, repeated, tag="3")]
     pub track_sids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// set to true to subscribe, false to unsubscribe from tracks
-    #[prost(bool, tag = "4")]
+    #[prost(bool, tag="4")]
     pub subscribe: bool,
     /// list of participants and their tracks
-    #[prost(message, repeated, tag = "5")]
+    #[prost(message, repeated, tag="5")]
     pub participant_tracks: ::prost::alloc::vec::Vec<ParticipantTracks>,
 }
 /// empty for now
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UpdateSubscriptionsResponse {}
+pub struct UpdateSubscriptionsResponse {
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendDataRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room: ::prost::alloc::string::String,
-    #[prost(bytes = "vec", tag = "2")]
+    #[prost(bytes="vec", tag="2")]
     pub data: ::prost::alloc::vec::Vec<u8>,
-    #[prost(enumeration = "data_packet::Kind", tag = "3")]
+    #[prost(enumeration="data_packet::Kind", tag="3")]
     pub kind: i32,
-    #[prost(string, repeated, tag = "4")]
+    #[prost(string, repeated, tag="4")]
     pub destination_sids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "5")]
+    #[prost(string, optional, tag="5")]
     pub topic: ::core::option::Option<::prost::alloc::string::String>,
 }
 ///
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SendDataResponse {}
+pub struct SendDataResponse {
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateRoomMetadataRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub room: ::prost::alloc::string::String,
     /// metadata to update. skipping updates if left empty
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub metadata: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateIngressRequest {
-    #[prost(enumeration = "IngressInput", tag = "1")]
+    #[prost(enumeration="IngressInput", tag="1")]
     pub input_type: i32,
     /// User provided identifier for the ingress
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
     /// room to publish to
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub room_name: ::prost::alloc::string::String,
     /// publish as participant
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub participant_identity: ::prost::alloc::string::String,
     /// name of publishing participant (used for display only)
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub participant_name: ::prost::alloc::string::String,
     /// whether to pass through the incoming media without transcoding, only compatible with some input types
-    #[prost(bool, tag = "8")]
+    #[prost(bool, tag="8")]
     pub bypass_transcoding: bool,
-    #[prost(message, optional, tag = "6")]
+    #[prost(message, optional, tag="6")]
     pub audio: ::core::option::Option<IngressAudioOptions>,
-    #[prost(message, optional, tag = "7")]
+    #[prost(message, optional, tag="7")]
     pub video: ::core::option::Option<IngressVideoOptions>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngressAudioOptions {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
-    #[prost(enumeration = "TrackSource", tag = "2")]
+    #[prost(enumeration="TrackSource", tag="2")]
     pub source: i32,
-    #[prost(oneof = "ingress_audio_options::EncodingOptions", tags = "3, 4")]
+    #[prost(oneof="ingress_audio_options::EncodingOptions", tags="3, 4")]
     pub encoding_options: ::core::option::Option<ingress_audio_options::EncodingOptions>,
 }
 /// Nested message and enum types in `IngressAudioOptions`.
 pub mod ingress_audio_options {
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum EncodingOptions {
-        #[prost(enumeration = "super::IngressAudioEncodingPreset", tag = "3")]
+        #[prost(enumeration="super::IngressAudioEncodingPreset", tag="3")]
         Preset(i32),
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         Options(super::IngressAudioEncodingOptions),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngressVideoOptions {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
-    #[prost(enumeration = "TrackSource", tag = "2")]
+    #[prost(enumeration="TrackSource", tag="2")]
     pub source: i32,
-    #[prost(oneof = "ingress_video_options::EncodingOptions", tags = "3, 4")]
+    #[prost(oneof="ingress_video_options::EncodingOptions", tags="3, 4")]
     pub encoding_options: ::core::option::Option<ingress_video_options::EncodingOptions>,
 }
 /// Nested message and enum types in `IngressVideoOptions`.
 pub mod ingress_video_options {
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum EncodingOptions {
-        #[prost(enumeration = "super::IngressVideoEncodingPreset", tag = "3")]
+        #[prost(enumeration="super::IngressVideoEncodingPreset", tag="3")]
         Preset(i32),
-        #[prost(message, tag = "4")]
+        #[prost(message, tag="4")]
         Options(super::IngressVideoEncodingOptions),
     }
 }
@@ -2575,81 +2575,83 @@ pub mod ingress_video_options {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngressAudioEncodingOptions {
     /// desired audio codec to publish to room
-    #[prost(enumeration = "AudioCodec", tag = "1")]
+    #[prost(enumeration="AudioCodec", tag="1")]
     pub audio_codec: i32,
-    #[prost(uint32, tag = "2")]
+    #[prost(uint32, tag="2")]
     pub bitrate: u32,
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag="3")]
     pub disable_dtx: bool,
-    #[prost(uint32, tag = "4")]
+    #[prost(uint32, tag="4")]
     pub channels: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngressVideoEncodingOptions {
     /// desired codec to publish to room
-    #[prost(enumeration = "VideoCodec", tag = "1")]
+    #[prost(enumeration="VideoCodec", tag="1")]
     pub video_codec: i32,
-    #[prost(double, tag = "2")]
+    #[prost(double, tag="2")]
     pub frame_rate: f64,
     /// simulcast layers to publish, when empty, should usually be set to layers at 1/2 and 1/4 of the dimensions
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag="3")]
     pub layers: ::prost::alloc::vec::Vec<VideoLayer>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngressInfo {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub ingress_id: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub stream_key: ::prost::alloc::string::String,
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub url: ::prost::alloc::string::String,
     /// for RTMP input, it'll be a rtmp:// URL
     /// for FILE input, it'll be a http:// URL
     /// for SRT input, it'll be a srt:// URL
-    #[prost(enumeration = "IngressInput", tag = "5")]
+    #[prost(enumeration="IngressInput", tag="5")]
     pub input_type: i32,
-    #[prost(bool, tag = "13")]
+    #[prost(bool, tag="13")]
     pub bypass_transcoding: bool,
-    #[prost(message, optional, tag = "6")]
+    #[prost(message, optional, tag="6")]
     pub audio: ::core::option::Option<IngressAudioOptions>,
-    #[prost(message, optional, tag = "7")]
+    #[prost(message, optional, tag="7")]
     pub video: ::core::option::Option<IngressVideoOptions>,
-    #[prost(string, tag = "8")]
+    #[prost(string, tag="8")]
     pub room_name: ::prost::alloc::string::String,
-    #[prost(string, tag = "9")]
+    #[prost(string, tag="9")]
     pub participant_identity: ::prost::alloc::string::String,
-    #[prost(string, tag = "10")]
+    #[prost(string, tag="10")]
     pub participant_name: ::prost::alloc::string::String,
-    #[prost(bool, tag = "11")]
+    #[prost(bool, tag="11")]
     pub reusable: bool,
     /// Description of error/stream non compliance and debug info for publisher otherwise (received bitrate, resolution, bandwidth)
-    #[prost(message, optional, tag = "12")]
+    #[prost(message, optional, tag="12")]
     pub state: ::core::option::Option<IngressState>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngressState {
-    #[prost(enumeration = "ingress_state::Status", tag = "1")]
+    #[prost(enumeration="ingress_state::Status", tag="1")]
     pub status: i32,
     /// Error/non compliance description if any
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub error: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "3")]
+    #[prost(message, optional, tag="3")]
     pub video: ::core::option::Option<InputVideoState>,
-    #[prost(message, optional, tag = "4")]
+    #[prost(message, optional, tag="4")]
     pub audio: ::core::option::Option<InputAudioState>,
     /// ID of the current/previous room published to
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub room_id: ::prost::alloc::string::String,
-    #[prost(int64, tag = "7")]
+    #[prost(int64, tag="7")]
     pub started_at: i64,
-    #[prost(int64, tag = "8")]
+    #[prost(int64, tag="8")]
     pub ended_at: i64,
-    #[prost(message, repeated, tag = "6")]
+    #[prost(string, tag="9")]
+    pub resource_id: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag="6")]
     pub tracks: ::prost::alloc::vec::Vec<TrackInfo>,
 }
 /// Nested message and enum types in `IngressState`.
@@ -2690,64 +2692,71 @@ pub mod ingress_state {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InputVideoState {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub mime_type: ::prost::alloc::string::String,
-    ///   uint32 bitrate = 2;
-    #[prost(uint32, tag = "3")]
+    #[prost(uint32, tag="2")]
+    pub average_bitrate: u32,
+    #[prost(uint32, tag="3")]
     pub width: u32,
-    #[prost(uint32, tag = "4")]
+    #[prost(uint32, tag="4")]
     pub height: u32,
-    #[prost(uint32, tag = "5")]
-    pub framerate: u32,
+    #[prost(double, tag="5")]
+    pub framerate: f64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InputAudioState {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub mime_type: ::prost::alloc::string::String,
-    ///   uint32 bitrate = 2;
-    #[prost(uint32, tag = "3")]
+    #[prost(uint32, tag="2")]
+    pub average_bitrate: u32,
+    #[prost(uint32, tag="3")]
     pub channels: u32,
-    #[prost(uint32, tag = "4")]
+    #[prost(uint32, tag="4")]
     pub sample_rate: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateIngressRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub ingress_id: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
-    #[prost(string, tag = "3")]
+    #[prost(string, tag="3")]
     pub room_name: ::prost::alloc::string::String,
-    #[prost(string, tag = "4")]
+    #[prost(string, tag="4")]
     pub participant_identity: ::prost::alloc::string::String,
-    #[prost(string, tag = "5")]
+    #[prost(string, tag="5")]
     pub participant_name: ::prost::alloc::string::String,
-    #[prost(bool, optional, tag = "8")]
+    #[prost(bool, optional, tag="8")]
     pub bypass_transcoding: ::core::option::Option<bool>,
-    #[prost(message, optional, tag = "6")]
+    #[prost(message, optional, tag="6")]
     pub audio: ::core::option::Option<IngressAudioOptions>,
-    #[prost(message, optional, tag = "7")]
+    #[prost(message, optional, tag="7")]
     pub video: ::core::option::Option<IngressVideoOptions>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListIngressRequest {
     /// when blank, lists all ingress endpoints
-    #[prost(string, tag = "1")]
+    ///
+    /// (optional, filter by room name)
+    #[prost(string, tag="1")]
     pub room_name: ::prost::alloc::string::String,
+    /// (optional, filter by ingress ID)
+    #[prost(string, tag="2")]
+    pub ingress_id: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListIngressResponse {
-    #[prost(message, repeated, tag = "1")]
+    #[prost(message, repeated, tag="1")]
     pub items: ::prost::alloc::vec::Vec<IngressInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteIngressRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub ingress_id: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -2853,29 +2862,29 @@ pub struct WebhookEvent {
     /// one of room_started, room_finished, participant_joined, participant_left,
     /// track_published, track_unpublished, egress_started, egress_updated, egress_ended,
     /// ingress_started, ingress_ended
-    #[prost(string, tag = "1")]
+    #[prost(string, tag="1")]
     pub event: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub room: ::core::option::Option<Room>,
     /// set when event is participant_* or track_*
-    #[prost(message, optional, tag = "3")]
+    #[prost(message, optional, tag="3")]
     pub participant: ::core::option::Option<ParticipantInfo>,
     /// set when event is egress_*
-    #[prost(message, optional, tag = "9")]
+    #[prost(message, optional, tag="9")]
     pub egress_info: ::core::option::Option<EgressInfo>,
     /// set when event is ingress_*
-    #[prost(message, optional, tag = "10")]
+    #[prost(message, optional, tag="10")]
     pub ingress_info: ::core::option::Option<IngressInfo>,
     /// set when event is track_*
-    #[prost(message, optional, tag = "8")]
+    #[prost(message, optional, tag="8")]
     pub track: ::core::option::Option<TrackInfo>,
     /// unique event uuid
-    #[prost(string, tag = "6")]
+    #[prost(string, tag="6")]
     pub id: ::prost::alloc::string::String,
     /// timestamp in seconds
-    #[prost(int64, tag = "7")]
+    #[prost(int64, tag="7")]
     pub created_at: i64,
-    #[prost(int32, tag = "11")]
+    #[prost(int32, tag="11")]
     pub num_dropped: i32,
 }
 include!("livekit.serde.rs");

--- a/livekit-protocol/src/livekit.serde.rs
+++ b/livekit-protocol/src/livekit.serde.rs
@@ -1,17 +1,3 @@
-// Copyright 2023 LiveKit, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 // @generated
 impl serde::Serialize for ActiveSpeakerUpdate {
     #[allow(deprecated)]
@@ -154,6 +140,9 @@ impl serde::Serialize for AddTrackRequest {
         if self.encryption != 0 {
             len += 1;
         }
+        if !self.stream.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.AddTrackRequest", len)?;
         if !self.cid.is_empty() {
             struct_ser.serialize_field("cid", &self.cid)?;
@@ -203,6 +192,9 @@ impl serde::Serialize for AddTrackRequest {
                 .ok_or_else(|| serde::ser::Error::custom(format!("Invalid variant {}", self.encryption)))?;
             struct_ser.serialize_field("encryption", &v)?;
         }
+        if !self.stream.is_empty() {
+            struct_ser.serialize_field("stream", &self.stream)?;
+        }
         struct_ser.end()
     }
 }
@@ -230,6 +222,7 @@ impl<'de> serde::Deserialize<'de> for AddTrackRequest {
             "disable_red",
             "disableRed",
             "encryption",
+            "stream",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -248,6 +241,7 @@ impl<'de> serde::Deserialize<'de> for AddTrackRequest {
             Stereo,
             DisableRed,
             Encryption,
+            Stream,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -283,6 +277,7 @@ impl<'de> serde::Deserialize<'de> for AddTrackRequest {
                             "stereo" => Ok(GeneratedField::Stereo),
                             "disableRed" | "disable_red" => Ok(GeneratedField::DisableRed),
                             "encryption" => Ok(GeneratedField::Encryption),
+                            "stream" => Ok(GeneratedField::Stream),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -316,6 +311,7 @@ impl<'de> serde::Deserialize<'de> for AddTrackRequest {
                 let mut stereo__ = None;
                 let mut disable_red__ = None;
                 let mut encryption__ = None;
+                let mut stream__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::Cid => {
@@ -406,6 +402,12 @@ impl<'de> serde::Deserialize<'de> for AddTrackRequest {
                             }
                             encryption__ = Some(map.next_value::<encryption::Type>()? as i32);
                         }
+                        GeneratedField::Stream => {
+                            if stream__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("stream"));
+                            }
+                            stream__ = Some(map.next_value()?);
+                        }
                     }
                 }
                 Ok(AddTrackRequest {
@@ -423,6 +425,7 @@ impl<'de> serde::Deserialize<'de> for AddTrackRequest {
                     stereo: stereo__.unwrap_or_default(),
                     disable_red: disable_red__.unwrap_or_default(),
                     encryption: encryption__.unwrap_or_default(),
+                    stream: stream__.unwrap_or_default(),
                 })
             }
         }
@@ -5817,6 +5820,9 @@ impl serde::Serialize for IngressState {
         if self.ended_at != 0 {
             len += 1;
         }
+        if !self.resource_id.is_empty() {
+            len += 1;
+        }
         if !self.tracks.is_empty() {
             len += 1;
         }
@@ -5844,6 +5850,9 @@ impl serde::Serialize for IngressState {
         if self.ended_at != 0 {
             struct_ser.serialize_field("endedAt", ToString::to_string(&self.ended_at).as_str())?;
         }
+        if !self.resource_id.is_empty() {
+            struct_ser.serialize_field("resourceId", &self.resource_id)?;
+        }
         if !self.tracks.is_empty() {
             struct_ser.serialize_field("tracks", &self.tracks)?;
         }
@@ -5867,6 +5876,8 @@ impl<'de> serde::Deserialize<'de> for IngressState {
             "startedAt",
             "ended_at",
             "endedAt",
+            "resource_id",
+            "resourceId",
             "tracks",
         ];
 
@@ -5879,6 +5890,7 @@ impl<'de> serde::Deserialize<'de> for IngressState {
             RoomId,
             StartedAt,
             EndedAt,
+            ResourceId,
             Tracks,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -5908,6 +5920,7 @@ impl<'de> serde::Deserialize<'de> for IngressState {
                             "roomId" | "room_id" => Ok(GeneratedField::RoomId),
                             "startedAt" | "started_at" => Ok(GeneratedField::StartedAt),
                             "endedAt" | "ended_at" => Ok(GeneratedField::EndedAt),
+                            "resourceId" | "resource_id" => Ok(GeneratedField::ResourceId),
                             "tracks" => Ok(GeneratedField::Tracks),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
@@ -5935,6 +5948,7 @@ impl<'de> serde::Deserialize<'de> for IngressState {
                 let mut room_id__ = None;
                 let mut started_at__ = None;
                 let mut ended_at__ = None;
+                let mut resource_id__ = None;
                 let mut tracks__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
@@ -5984,6 +5998,12 @@ impl<'de> serde::Deserialize<'de> for IngressState {
                                 Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::ResourceId => {
+                            if resource_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("resourceId"));
+                            }
+                            resource_id__ = Some(map.next_value()?);
+                        }
                         GeneratedField::Tracks => {
                             if tracks__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("tracks"));
@@ -6000,6 +6020,7 @@ impl<'de> serde::Deserialize<'de> for IngressState {
                     room_id: room_id__.unwrap_or_default(),
                     started_at: started_at__.unwrap_or_default(),
                     ended_at: ended_at__.unwrap_or_default(),
+                    resource_id: resource_id__.unwrap_or_default(),
                     tracks: tracks__.unwrap_or_default(),
                 })
             }
@@ -6456,6 +6477,9 @@ impl serde::Serialize for InputAudioState {
         if !self.mime_type.is_empty() {
             len += 1;
         }
+        if self.average_bitrate != 0 {
+            len += 1;
+        }
         if self.channels != 0 {
             len += 1;
         }
@@ -6465,6 +6489,9 @@ impl serde::Serialize for InputAudioState {
         let mut struct_ser = serializer.serialize_struct("livekit.InputAudioState", len)?;
         if !self.mime_type.is_empty() {
             struct_ser.serialize_field("mimeType", &self.mime_type)?;
+        }
+        if self.average_bitrate != 0 {
+            struct_ser.serialize_field("averageBitrate", &self.average_bitrate)?;
         }
         if self.channels != 0 {
             struct_ser.serialize_field("channels", &self.channels)?;
@@ -6484,6 +6511,8 @@ impl<'de> serde::Deserialize<'de> for InputAudioState {
         const FIELDS: &[&str] = &[
             "mime_type",
             "mimeType",
+            "average_bitrate",
+            "averageBitrate",
             "channels",
             "sample_rate",
             "sampleRate",
@@ -6492,6 +6521,7 @@ impl<'de> serde::Deserialize<'de> for InputAudioState {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             MimeType,
+            AverageBitrate,
             Channels,
             SampleRate,
         }
@@ -6516,6 +6546,7 @@ impl<'de> serde::Deserialize<'de> for InputAudioState {
                     {
                         match value {
                             "mimeType" | "mime_type" => Ok(GeneratedField::MimeType),
+                            "averageBitrate" | "average_bitrate" => Ok(GeneratedField::AverageBitrate),
                             "channels" => Ok(GeneratedField::Channels),
                             "sampleRate" | "sample_rate" => Ok(GeneratedField::SampleRate),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
@@ -6538,6 +6569,7 @@ impl<'de> serde::Deserialize<'de> for InputAudioState {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut mime_type__ = None;
+                let mut average_bitrate__ = None;
                 let mut channels__ = None;
                 let mut sample_rate__ = None;
                 while let Some(k) = map.next_key()? {
@@ -6547,6 +6579,14 @@ impl<'de> serde::Deserialize<'de> for InputAudioState {
                                 return Err(serde::de::Error::duplicate_field("mimeType"));
                             }
                             mime_type__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::AverageBitrate => {
+                            if average_bitrate__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("averageBitrate"));
+                            }
+                            average_bitrate__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
                         }
                         GeneratedField::Channels => {
                             if channels__.is_some() {
@@ -6568,6 +6608,7 @@ impl<'de> serde::Deserialize<'de> for InputAudioState {
                 }
                 Ok(InputAudioState {
                     mime_type: mime_type__.unwrap_or_default(),
+                    average_bitrate: average_bitrate__.unwrap_or_default(),
                     channels: channels__.unwrap_or_default(),
                     sample_rate: sample_rate__.unwrap_or_default(),
                 })
@@ -6587,18 +6628,24 @@ impl serde::Serialize for InputVideoState {
         if !self.mime_type.is_empty() {
             len += 1;
         }
+        if self.average_bitrate != 0 {
+            len += 1;
+        }
         if self.width != 0 {
             len += 1;
         }
         if self.height != 0 {
             len += 1;
         }
-        if self.framerate != 0 {
+        if self.framerate != 0. {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("livekit.InputVideoState", len)?;
         if !self.mime_type.is_empty() {
             struct_ser.serialize_field("mimeType", &self.mime_type)?;
+        }
+        if self.average_bitrate != 0 {
+            struct_ser.serialize_field("averageBitrate", &self.average_bitrate)?;
         }
         if self.width != 0 {
             struct_ser.serialize_field("width", &self.width)?;
@@ -6606,7 +6653,7 @@ impl serde::Serialize for InputVideoState {
         if self.height != 0 {
             struct_ser.serialize_field("height", &self.height)?;
         }
-        if self.framerate != 0 {
+        if self.framerate != 0. {
             struct_ser.serialize_field("framerate", &self.framerate)?;
         }
         struct_ser.end()
@@ -6621,6 +6668,8 @@ impl<'de> serde::Deserialize<'de> for InputVideoState {
         const FIELDS: &[&str] = &[
             "mime_type",
             "mimeType",
+            "average_bitrate",
+            "averageBitrate",
             "width",
             "height",
             "framerate",
@@ -6629,6 +6678,7 @@ impl<'de> serde::Deserialize<'de> for InputVideoState {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             MimeType,
+            AverageBitrate,
             Width,
             Height,
             Framerate,
@@ -6654,6 +6704,7 @@ impl<'de> serde::Deserialize<'de> for InputVideoState {
                     {
                         match value {
                             "mimeType" | "mime_type" => Ok(GeneratedField::MimeType),
+                            "averageBitrate" | "average_bitrate" => Ok(GeneratedField::AverageBitrate),
                             "width" => Ok(GeneratedField::Width),
                             "height" => Ok(GeneratedField::Height),
                             "framerate" => Ok(GeneratedField::Framerate),
@@ -6677,6 +6728,7 @@ impl<'de> serde::Deserialize<'de> for InputVideoState {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut mime_type__ = None;
+                let mut average_bitrate__ = None;
                 let mut width__ = None;
                 let mut height__ = None;
                 let mut framerate__ = None;
@@ -6687,6 +6739,14 @@ impl<'de> serde::Deserialize<'de> for InputVideoState {
                                 return Err(serde::de::Error::duplicate_field("mimeType"));
                             }
                             mime_type__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::AverageBitrate => {
+                            if average_bitrate__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("averageBitrate"));
+                            }
+                            average_bitrate__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
                         }
                         GeneratedField::Width => {
                             if width__.is_some() {
@@ -6716,6 +6776,7 @@ impl<'de> serde::Deserialize<'de> for InputVideoState {
                 }
                 Ok(InputVideoState {
                     mime_type: mime_type__.unwrap_or_default(),
+                    average_bitrate: average_bitrate__.unwrap_or_default(),
                     width: width__.unwrap_or_default(),
                     height: height__.unwrap_or_default(),
                     framerate: framerate__.unwrap_or_default(),
@@ -7377,9 +7438,15 @@ impl serde::Serialize for ListIngressRequest {
         if !self.room_name.is_empty() {
             len += 1;
         }
+        if !self.ingress_id.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.ListIngressRequest", len)?;
         if !self.room_name.is_empty() {
             struct_ser.serialize_field("roomName", &self.room_name)?;
+        }
+        if !self.ingress_id.is_empty() {
+            struct_ser.serialize_field("ingressId", &self.ingress_id)?;
         }
         struct_ser.end()
     }
@@ -7393,11 +7460,14 @@ impl<'de> serde::Deserialize<'de> for ListIngressRequest {
         const FIELDS: &[&str] = &[
             "room_name",
             "roomName",
+            "ingress_id",
+            "ingressId",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             RoomName,
+            IngressId,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -7420,6 +7490,7 @@ impl<'de> serde::Deserialize<'de> for ListIngressRequest {
                     {
                         match value {
                             "roomName" | "room_name" => Ok(GeneratedField::RoomName),
+                            "ingressId" | "ingress_id" => Ok(GeneratedField::IngressId),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -7440,6 +7511,7 @@ impl<'de> serde::Deserialize<'de> for ListIngressRequest {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut room_name__ = None;
+                let mut ingress_id__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::RoomName => {
@@ -7448,10 +7520,17 @@ impl<'de> serde::Deserialize<'de> for ListIngressRequest {
                             }
                             room_name__ = Some(map.next_value()?);
                         }
+                        GeneratedField::IngressId => {
+                            if ingress_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("ingressId"));
+                            }
+                            ingress_id__ = Some(map.next_value()?);
+                        }
                     }
                 }
                 Ok(ListIngressRequest {
                     room_name: room_name__.unwrap_or_default(),
+                    ingress_id: ingress_id__.unwrap_or_default(),
                 })
             }
         }
@@ -9118,6 +9197,135 @@ impl<'de> serde::Deserialize<'de> for Ping {
         deserializer.deserialize_struct("livekit.Ping", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for PlayoutDelay {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.enabled {
+            len += 1;
+        }
+        if self.min != 0 {
+            len += 1;
+        }
+        if self.max != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("livekit.PlayoutDelay", len)?;
+        if self.enabled {
+            struct_ser.serialize_field("enabled", &self.enabled)?;
+        }
+        if self.min != 0 {
+            struct_ser.serialize_field("min", &self.min)?;
+        }
+        if self.max != 0 {
+            struct_ser.serialize_field("max", &self.max)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for PlayoutDelay {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "enabled",
+            "min",
+            "max",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Enabled,
+            Min,
+            Max,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "enabled" => Ok(GeneratedField::Enabled),
+                            "min" => Ok(GeneratedField::Min),
+                            "max" => Ok(GeneratedField::Max),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = PlayoutDelay;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct livekit.PlayoutDelay")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<PlayoutDelay, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut enabled__ = None;
+                let mut min__ = None;
+                let mut max__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::Enabled => {
+                            if enabled__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("enabled"));
+                            }
+                            enabled__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::Min => {
+                            if min__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("min"));
+                            }
+                            min__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Max => {
+                            if max__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("max"));
+                            }
+                            max__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(PlayoutDelay {
+                    enabled: enabled__.unwrap_or_default(),
+                    min: min__.unwrap_or_default(),
+                    max: max__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("livekit.PlayoutDelay", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for Pong {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -10668,6 +10876,9 @@ impl serde::Serialize for Room {
         if self.active_recording {
             len += 1;
         }
+        if self.playout_delay.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.Room", len)?;
         if !self.sid.is_empty() {
             struct_ser.serialize_field("sid", &self.sid)?;
@@ -10702,6 +10913,9 @@ impl serde::Serialize for Room {
         if self.active_recording {
             struct_ser.serialize_field("activeRecording", &self.active_recording)?;
         }
+        if let Some(v) = self.playout_delay.as_ref() {
+            struct_ser.serialize_field("playoutDelay", v)?;
+        }
         struct_ser.end()
     }
 }
@@ -10731,6 +10945,8 @@ impl<'de> serde::Deserialize<'de> for Room {
             "numPublishers",
             "active_recording",
             "activeRecording",
+            "playout_delay",
+            "playoutDelay",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -10746,6 +10962,7 @@ impl<'de> serde::Deserialize<'de> for Room {
             NumParticipants,
             NumPublishers,
             ActiveRecording,
+            PlayoutDelay,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -10778,6 +10995,7 @@ impl<'de> serde::Deserialize<'de> for Room {
                             "numParticipants" | "num_participants" => Ok(GeneratedField::NumParticipants),
                             "numPublishers" | "num_publishers" => Ok(GeneratedField::NumPublishers),
                             "activeRecording" | "active_recording" => Ok(GeneratedField::ActiveRecording),
+                            "playoutDelay" | "playout_delay" => Ok(GeneratedField::PlayoutDelay),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -10808,6 +11026,7 @@ impl<'de> serde::Deserialize<'de> for Room {
                 let mut num_participants__ = None;
                 let mut num_publishers__ = None;
                 let mut active_recording__ = None;
+                let mut playout_delay__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::Sid => {
@@ -10886,6 +11105,12 @@ impl<'de> serde::Deserialize<'de> for Room {
                             }
                             active_recording__ = Some(map.next_value()?);
                         }
+                        GeneratedField::PlayoutDelay => {
+                            if playout_delay__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("playoutDelay"));
+                            }
+                            playout_delay__ = map.next_value()?;
+                        }
                     }
                 }
                 Ok(Room {
@@ -10900,6 +11125,7 @@ impl<'de> serde::Deserialize<'de> for Room {
                     num_participants: num_participants__.unwrap_or_default(),
                     num_publishers: num_publishers__.unwrap_or_default(),
                     active_recording: active_recording__.unwrap_or_default(),
+                    playout_delay: playout_delay__,
                 })
             }
         }
@@ -16719,6 +16945,9 @@ impl serde::Serialize for TrackInfo {
         if self.encryption != 0 {
             len += 1;
         }
+        if !self.stream.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.TrackInfo", len)?;
         if !self.sid.is_empty() {
             struct_ser.serialize_field("sid", &self.sid)?;
@@ -16774,6 +17003,9 @@ impl serde::Serialize for TrackInfo {
                 .ok_or_else(|| serde::ser::Error::custom(format!("Invalid variant {}", self.encryption)))?;
             struct_ser.serialize_field("encryption", &v)?;
         }
+        if !self.stream.is_empty() {
+            struct_ser.serialize_field("stream", &self.stream)?;
+        }
         struct_ser.end()
     }
 }
@@ -16803,6 +17035,7 @@ impl<'de> serde::Deserialize<'de> for TrackInfo {
             "disable_red",
             "disableRed",
             "encryption",
+            "stream",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -16823,6 +17056,7 @@ impl<'de> serde::Deserialize<'de> for TrackInfo {
             Stereo,
             DisableRed,
             Encryption,
+            Stream,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -16860,6 +17094,7 @@ impl<'de> serde::Deserialize<'de> for TrackInfo {
                             "stereo" => Ok(GeneratedField::Stereo),
                             "disableRed" | "disable_red" => Ok(GeneratedField::DisableRed),
                             "encryption" => Ok(GeneratedField::Encryption),
+                            "stream" => Ok(GeneratedField::Stream),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -16895,6 +17130,7 @@ impl<'de> serde::Deserialize<'de> for TrackInfo {
                 let mut stereo__ = None;
                 let mut disable_red__ = None;
                 let mut encryption__ = None;
+                let mut stream__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::Sid => {
@@ -16997,6 +17233,12 @@ impl<'de> serde::Deserialize<'de> for TrackInfo {
                             }
                             encryption__ = Some(map.next_value::<encryption::Type>()? as i32);
                         }
+                        GeneratedField::Stream => {
+                            if stream__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("stream"));
+                            }
+                            stream__ = Some(map.next_value()?);
+                        }
                     }
                 }
                 Ok(TrackInfo {
@@ -17016,6 +17258,7 @@ impl<'de> serde::Deserialize<'de> for TrackInfo {
                     stereo: stereo__.unwrap_or_default(),
                     disable_red: disable_red__.unwrap_or_default(),
                     encryption: encryption__.unwrap_or_default(),
+                    stream: stream__.unwrap_or_default(),
                 })
             }
         }

--- a/livekit-webrtc/src/native/peer_connection.rs
+++ b/livekit-webrtc/src/native/peer_connection.rs
@@ -419,6 +419,10 @@ impl PeerConnection {
         }
     }
 
+    pub fn restart_ice(&self) {
+        self.sys_handle.restart_ice();
+    }
+
     pub fn close(&self) {
         self.sys_handle.close();
     }

--- a/livekit-webrtc/src/peer_connection.rs
+++ b/livekit-webrtc/src/peer_connection.rs
@@ -176,6 +176,10 @@ impl PeerConnection {
         self.handle.close()
     }
 
+    pub fn restart_ice(&self) {
+        self.handle.restart_ice()
+    }
+
     pub fn connection_state(&self) -> PeerConnectionState {
         self.handle.connection_state()
     }

--- a/livekit-webrtc/src/rtp_parameters.rs
+++ b/livekit-webrtc/src/rtp_parameters.rs
@@ -36,7 +36,7 @@ pub struct RtpParameters {
     pub rtcp: RtcpParameters,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RtpCodecParameters {
     pub payload_type: u8,
     pub mime_type: String, // read-only
@@ -78,17 +78,6 @@ pub struct RtpHeaderExtensionCapability {
 pub struct RtpCapabilities {
     pub codecs: Vec<RtpCodecCapability>,
     pub header_extensions: Vec<RtpHeaderExtensionCapability>,
-}
-
-impl Default for RtpCodecParameters {
-    fn default() -> Self {
-        Self {
-            payload_type: 0,
-            mime_type: String::default(),
-            clock_rate: None,
-            channels: None,
-        }
-    }
 }
 
 impl Default for RtpEncodingParameters {

--- a/livekit-webrtc/src/session_description.rs
+++ b/livekit-webrtc/src/session_description.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use crate::imp::session_description as sd_imp;
-use std::{fmt::Debug, str::FromStr};
+use std::{
+    fmt::{Debug, Display},
+    str::FromStr,
+};
 use thiserror::Error;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -35,6 +38,18 @@ impl FromStr for SdpType {
             "rollback" => Ok(Self::Rollback),
             _ => Err("invalid SdpType"),
         }
+    }
+}
+
+impl Display for SdpType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            SdpType::Offer => "offer",
+            SdpType::PrAnswer => "pranswer",
+            SdpType::Answer => "answer",
+            SdpType::Rollback => "rollback",
+        };
+        write!(f, "{}", s)
     }
 }
 

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -179,14 +179,13 @@ impl Room {
             SignalOptions {
                 auto_subscribe: options.auto_subscribe,
                 adaptive_stream: options.adaptive_stream,
-                ..Default::default()
             },
         )
         .await?;
         let rtc_engine = Arc::new(rtc_engine);
 
         let join_response = rtc_engine.last_info().join_response;
-        let pi = join_response.participant.unwrap().clone();
+        let pi = join_response.participant.unwrap();
         let local_participant = LocalParticipant::new(
             rtc_engine.clone(),
             pi.sid.try_into().unwrap(),
@@ -409,9 +408,9 @@ impl RoomSession {
                 let payload = Arc::new(payload);
                 if let Some(participant) = self.get_participant(&participant_sid) {
                     self.dispatcher.dispatch(&RoomEvent::DataReceived {
-                        payload: payload.clone(),
+                        payload,
                         kind,
-                        participant: participant.clone(),
+                        participant,
                     });
                 }
             }
@@ -440,7 +439,7 @@ impl RoomSession {
         info.state = state;
         self.dispatcher
             .dispatch(&RoomEvent::ConnectionStateChanged(state));
-        return true;
+        true
     }
 
     /// Update the participants inside a Room.
@@ -483,8 +482,7 @@ impl RoomSession {
                     )
                 };
 
-                let _ = self
-                    .dispatcher
+                self.dispatcher
                     .dispatch(&RoomEvent::ParticipantConnected(remote_participant.clone()));
 
                 remote_participant.update_info(pi.clone());
@@ -502,12 +500,10 @@ impl RoomSession {
             let participant = {
                 if sid == self.local_participant.sid() {
                     Participant::Local(self.local_participant.clone())
+                } else if let Some(participant) = self.get_participant(&sid) {
+                    Participant::Remote(participant)
                 } else {
-                    if let Some(participant) = self.get_participant(&sid) {
-                        Participant::Remote(participant)
-                    } else {
-                        continue;
-                    }
+                    continue;
                 }
             };
 
@@ -522,8 +518,7 @@ impl RoomSession {
         speakers.sort_by(|a, b| a.audio_level().partial_cmp(&b.audio_level()).unwrap());
         *self.active_speakers.write() = speakers.clone();
 
-        let _ = self
-            .dispatcher
+        self.dispatcher
             .dispatch(&RoomEvent::ActiveSpeakersChanged { speakers });
     }
 
@@ -536,12 +531,10 @@ impl RoomSession {
             let participant = {
                 if sid == self.local_participant.sid() {
                     Participant::Local(self.local_participant.clone())
+                } else if let Some(participant) = self.get_participant(&sid) {
+                    Participant::Remote(participant)
                 } else {
-                    if let Some(participant) = self.get_participant(&sid) {
-                        Participant::Remote(participant)
-                    } else {
-                        continue;
-                    }
+                    continue;
                 }
             };
 
@@ -572,14 +565,17 @@ impl RoomSession {
             }
         }
 
+        let answer = last_info.subscriber_answer.unwrap();
+        let offer = last_info.subscriber_offer.unwrap();
+
         let sync_state = proto::SyncState {
             answer: Some(proto::SessionDescription {
-                sdp: last_info.subscriber_answer.unwrap().to_string(),
-                r#type: "answer".to_string(),
+                sdp: answer.to_string(),
+                r#type: answer.sdp_type().to_string(),
             }),
             offer: Some(proto::SessionDescription {
-                sdp: last_info.subscriber_offer.unwrap().to_string(),
-                r#type: "offer".to_string(),
+                sdp: offer.to_string(),
+                r#type: offer.sdp_type().to_string(),
             }),
             subscription: Some(proto::UpdateSubscription {
                 track_sids,
@@ -754,7 +750,7 @@ impl RoomSession {
 fn unpack_stream_id(stream_id: &str) -> Option<(&str, &str)> {
     let split: Vec<&str> = stream_id.split('|').collect();
     if split.len() == 2 {
-        let participant_sid = split.get(0).unwrap();
+        let participant_sid = split.first().unwrap();
         let track_sid = split.get(1).unwrap();
         Some((participant_sid, track_sid))
     } else {

--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -150,7 +150,9 @@ pub fn compute_video_encodings(
     let low_preset = simulcast_presets.pop();
 
     let size = u32::max(width, height);
+
     if size >= 960 && low_preset.is_some() {
+        #[allow(clippy::unnecessary_unwrap)]
         return into_rtp_encodings(
             width,
             height,
@@ -370,7 +372,7 @@ pub mod screenshare {
             initial.height / SCALE_DOWN_FACTOR,
             u64::max(
                 150_000,
-                initial.encoding.max_bitrate as u64
+                initial.encoding.max_bitrate
                     / (SCALE_DOWN_FACTOR.pow(2) as u64
                         * (initial.encoding.max_framerate / FPS) as u64),
             ),

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -182,13 +182,15 @@ impl LocalParticipant {
         let transceiver = self
             .inner
             .rtc_engine
-            .create_sender(track.clone(), options, encodings)
+            .create_sender(track.clone(), options.clone(), encodings)
             .await?;
 
         track.set_transceiver(Some(transceiver));
         track.enable();
 
         self.inner.rtc_engine.publisher_negotiation_needed();
+
+        publication.update_publish_options(options);
         self.add_publication(TrackPublication::Local(publication.clone()));
 
         if let Some(local_track_published) = self.local.events.local_track_published.lock().as_ref()
@@ -201,10 +203,10 @@ impl LocalParticipant {
 
     pub async fn unpublish_track(
         &self,
-        track: TrackSid,
-        _stop_on_unpublish: bool,
+        track: &TrackSid,
+        // _stop_on_unpublish: bool,
     ) -> RoomResult<LocalTrackPublication> {
-        let publication = self.inner.tracks.write().remove(&track);
+        let publication = self.inner.tracks.write().remove(track);
         if let Some(TrackPublication::Local(publication)) = publication {
             let track = publication.track().unwrap();
             let sender = track.transceiver().unwrap().sender();

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -76,7 +76,7 @@ impl LocalParticipant {
         self.inner.tracks.read().clone()
     }
 
-    pub(crate) fn update_info(self: &Self, info: proto::ParticipantInfo) {
+    pub(crate) fn update_info(&self, info: proto::ParticipantInfo) {
         super::update_info(&self.inner, &Participant::Local(self.clone()), info);
     }
 
@@ -140,7 +140,7 @@ impl LocalParticipant {
     ) -> RoomResult<LocalTrackPublication> {
         let mut req = proto::AddTrackRequest {
             cid: track.rtc_track().id(),
-            name: track.name().clone(),
+            name: track.name(),
             r#type: proto::TrackType::from(track.kind()) as i32,
             muted: track.is_muted(),
             source: proto::TrackSource::from(options.source) as i32,

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -28,12 +28,13 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+type LocalTrackPublishedHandler = Box<dyn Fn(LocalParticipant, LocalTrackPublication) + Send>;
+type LocalTrackUnpublishedHandler = Box<dyn Fn(LocalParticipant, LocalTrackPublication) + Send>;
+
 #[derive(Default)]
 struct LocalEvents {
-    local_track_published:
-        Mutex<Option<Box<dyn Fn(LocalParticipant, LocalTrackPublication) + Send>>>,
-    local_track_unpublished:
-        Mutex<Option<Box<dyn Fn(LocalParticipant, LocalTrackPublication) + Send>>>,
+    local_track_published: Mutex<Option<LocalTrackPublishedHandler>>,
+    local_track_unpublished: Mutex<Option<LocalTrackUnpublishedHandler>>,
 }
 
 struct LocalInfo {

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -79,10 +79,13 @@ struct ParticipantInfo {
     pub connection_quality: ConnectionQuality,
 }
 
+type TrackMutedHandler = Box<dyn Fn(Participant, TrackPublication, Track) + Send>;
+type TrackUnmutedHandler = Box<dyn Fn(Participant, TrackPublication, Track) + Send>;
+
 #[derive(Default)]
 struct ParticipantEvents {
-    track_muted: Mutex<Option<Box<dyn Fn(Participant, TrackPublication, Track) + Send>>>,
-    track_unmuted: Mutex<Option<Box<dyn Fn(Participant, TrackPublication, Track) + Send>>>,
+    track_muted: Mutex<Option<TrackMutedHandler>>,
+    track_unmuted: Mutex<Option<TrackUnmutedHandler>>,
 }
 
 pub(super) struct ParticipantInner {

--- a/livekit/src/room/participant/remote_participant.rs
+++ b/livekit/src/room/participant/remote_participant.rs
@@ -105,7 +105,7 @@ impl RemoteParticipant {
                 TrackKind::Audio => {
                     if let MediaStreamTrack::Audio(rtc_track) = media_track {
                         let audio_track = RemoteAudioTrack::new(
-                            remote_publication.sid().into(),
+                            remote_publication.sid(),
                             remote_publication.name(),
                             rtc_track,
                         );
@@ -117,7 +117,7 @@ impl RemoteParticipant {
                 TrackKind::Video => {
                     if let MediaStreamTrack::Video(rtc_track) = media_track {
                         let video_track = RemoteVideoTrack::new(
-                            remote_publication.sid().into(),
+                            remote_publication.sid(),
                             remote_publication.name(),
                             rtc_track,
                         );
@@ -133,7 +133,7 @@ impl RemoteParticipant {
             //track.set_muted(remote_publication.is_muted());
             track.update_info(proto::TrackInfo {
                 sid: remote_publication.sid().to_string(),
-                name: remote_publication.name().to_string(),
+                name: remote_publication.name(),
                 r#type: proto::TrackType::from(remote_publication.kind()) as i32,
                 source: proto::TrackSource::from(remote_publication.source()) as i32,
                 ..Default::default()
@@ -142,7 +142,7 @@ impl RemoteParticipant {
             self.add_publication(TrackPublication::Remote(remote_publication.clone()));
             track.enable();
 
-            remote_publication.set_track(Some(track.into())); // This will fire TrackSubscribed on the publication
+            remote_publication.set_track(Some(track)); // This will fire TrackSubscribed on the publication
         } else {
             log::error!("could not find published track with sid: {:?}", sid);
 
@@ -169,7 +169,7 @@ impl RemoteParticipant {
             self.remove_publication(sid);
 
             if let Some(track_unpublished) = self.remote.events.track_unpublished.lock().as_ref() {
-                track_unpublished(self.clone(), publication.clone());
+                track_unpublished(self.clone(), publication);
             }
         }
     }
@@ -202,7 +202,7 @@ impl RemoteParticipant {
 
         // remove tracks that are no longer valid
         let tracks = self.inner.tracks.read().clone();
-        for (sid, _) in &tracks {
+        for sid in tracks.keys() {
             if valid_tracks.contains(sid) {
                 continue;
             }

--- a/livekit/src/room/participant/remote_participant.rs
+++ b/livekit/src/room/participant/remote_participant.rs
@@ -28,16 +28,21 @@ use tokio::time::timeout;
 
 const ADD_TRACK_TIMEOUT: Duration = Duration::from_secs(5);
 
+type TrackPublishedHandler = Box<dyn Fn(RemoteParticipant, RemoteTrackPublication) + Send>;
+type TrackUnpublishedHandler = Box<dyn Fn(RemoteParticipant, RemoteTrackPublication) + Send>;
+type TrackSubscribedHandler =
+    Box<dyn Fn(RemoteParticipant, RemoteTrackPublication, RemoteTrack) + Send>;
+type TrackUnsubscribedHandler =
+    Box<dyn Fn(RemoteParticipant, RemoteTrackPublication, RemoteTrack) + Send>;
+type TrackSubscriptionFailedHandler = Box<dyn Fn(RemoteParticipant, TrackSid, TrackError) + Send>;
+
 #[derive(Default)]
 struct RemoteEvents {
-    track_published: Mutex<Option<Box<dyn Fn(RemoteParticipant, RemoteTrackPublication) + Send>>>,
-    track_unpublished: Mutex<Option<Box<dyn Fn(RemoteParticipant, RemoteTrackPublication) + Send>>>,
-    track_subscribed:
-        Mutex<Option<Box<dyn Fn(RemoteParticipant, RemoteTrackPublication, RemoteTrack) + Send>>>,
-    track_unsubscribed:
-        Mutex<Option<Box<dyn Fn(RemoteParticipant, RemoteTrackPublication, RemoteTrack) + Send>>>,
-    track_subscription_failed:
-        Mutex<Option<Box<dyn Fn(RemoteParticipant, TrackSid, TrackError) + Send>>>,
+    track_published: Mutex<Option<TrackPublishedHandler>>,
+    track_unpublished: Mutex<Option<TrackUnpublishedHandler>>,
+    track_subscribed: Mutex<Option<TrackSubscribedHandler>>,
+    track_unsubscribed: Mutex<Option<TrackUnsubscribedHandler>>,
+    track_subscription_failed: Mutex<Option<TrackSubscriptionFailedHandler>>,
 }
 
 struct RemoteInfo {

--- a/livekit/src/room/publication/mod.rs
+++ b/livekit/src/room/publication/mod.rs
@@ -93,10 +93,13 @@ struct PublicationInfo {
     pub proto_info: proto::TrackInfo,
 }
 
+pub(crate) type MutedHandler = Box<dyn Fn(TrackPublication, Track) + Send>;
+pub(crate) type UnmutedHandler = Box<dyn Fn(TrackPublication, Track) + Send>;
+
 #[derive(Default)]
 struct PublicationEvents {
-    muted: Mutex<Option<Box<dyn Fn(TrackPublication, Track) + Send>>>,
-    unmuted: Mutex<Option<Box<dyn Fn(TrackPublication, Track) + Send>>>,
+    muted: Mutex<Option<MutedHandler>>,
+    unmuted: Mutex<Option<UnmutedHandler>>,
 }
 
 pub(super) struct TrackPublicationInner {

--- a/livekit/src/room/publication/mod.rs
+++ b/livekit/src/room/publication/mod.rs
@@ -111,16 +111,10 @@ pub(super) fn new_inner(
     let info = PublicationInfo {
         track,
         proto_info: info.clone(),
+        source: info.source().try_into().unwrap(),
+        kind: info.r#type().try_into().unwrap(),
         name: info.name,
         sid: info.sid.try_into().unwrap(),
-        kind: proto::TrackType::from_i32(info.r#type)
-            .unwrap()
-            .try_into()
-            .unwrap(),
-        source: proto::TrackSource::from_i32(info.source)
-            .unwrap()
-            .try_into()
-            .unwrap(),
         simulcasted: info.simulcast,
         dimension: TrackDimension(info.width, info.height),
         mime_type: info.mime_type,
@@ -139,13 +133,13 @@ pub(super) fn update_info(
     new_info: proto::TrackInfo,
 ) {
     let mut info = inner.info.write();
+    info.kind = TrackKind::try_from(new_info.r#type()).unwrap();
+    info.source = TrackSource::from(new_info.source());
     info.proto_info = new_info.clone();
     info.name = new_info.name;
     info.sid = new_info.sid.try_into().unwrap();
     info.dimension = TrackDimension(new_info.width, new_info.height);
     info.mime_type = new_info.mime_type;
-    info.kind = TrackKind::try_from(proto::TrackType::from_i32(new_info.r#type).unwrap()).unwrap();
-    info.source = TrackSource::from(proto::TrackSource::from_i32(new_info.source).unwrap());
     info.simulcasted = new_info.simulcast;
 }
 

--- a/livekit/src/room/publication/remote.rs
+++ b/livekit/src/room/publication/remote.rs
@@ -278,7 +278,7 @@ impl RemoteTrackPublication {
     }
 
     pub fn dimension(&self) -> TrackDimension {
-        self.inner.info.read().dimension.clone()
+        self.inner.info.read().dimension
     }
 
     pub fn track(&self) -> Option<RemoteTrack> {

--- a/livekit/src/room/publication/remote.rs
+++ b/livekit/src/room/publication/remote.rs
@@ -19,17 +19,21 @@ use parking_lot::{Mutex, RwLock};
 use std::fmt::Debug;
 use std::sync::Arc;
 
+type SubscribedHandler = Box<dyn Fn(RemoteTrackPublication, RemoteTrack) + Send>;
+type UnsubscribedHandler = Box<dyn Fn(RemoteTrackPublication, RemoteTrack) + Send>;
+type SubscriptionStatusChangedHandler =
+    Box<dyn Fn(RemoteTrackPublication, SubscriptionStatus, SubscriptionStatus) + Send>; // old_status, new_status
+type PermissionStatusChangedHandler =
+    Box<dyn Fn(RemoteTrackPublication, PermissionStatus, PermissionStatus) + Send>; // old_status, new_status
+type SubscriptionUpdateNeededHandler = Box<dyn Fn(RemoteTrackPublication, bool) + Send>;
+
 #[derive(Default)]
 struct RemoteEvents {
-    subscribed: Mutex<Option<Box<dyn Fn(RemoteTrackPublication, RemoteTrack) + Send>>>,
-    unsubscribed: Mutex<Option<Box<dyn Fn(RemoteTrackPublication, RemoteTrack) + Send>>>,
-    subscription_status_changed: Mutex<
-        Option<Box<dyn Fn(RemoteTrackPublication, SubscriptionStatus, SubscriptionStatus) + Send>>,
-    >, // Old status, new status
-    permission_status_changed: Mutex<
-        Option<Box<dyn Fn(RemoteTrackPublication, PermissionStatus, PermissionStatus) + Send>>,
-    >, // Old status, new status
-    subscription_update_needed: Mutex<Option<Box<dyn Fn(RemoteTrackPublication, bool) + Send>>>,
+    subscribed: Mutex<Option<SubscribedHandler>>,
+    unsubscribed: Mutex<Option<UnsubscribedHandler>>,
+    subscription_status_changed: Mutex<Option<SubscriptionStatusChangedHandler>>,
+    permission_status_changed: Mutex<Option<PermissionStatusChangedHandler>>,
+    subscription_update_needed: Mutex<Option<SubscriptionUpdateNeededHandler>>,
 }
 
 #[derive(Debug)]

--- a/livekit/src/room/track/audio_track.rs
+++ b/livekit/src/room/track/audio_track.rs
@@ -29,8 +29,8 @@ impl AudioTrack {
 
     pub fn rtc_track(&self) -> RtcAudioTrack {
         match self {
-            Self::Local(track) => track.rtc_track().into(),
-            Self::Remote(track) => track.rtc_track().into(),
+            Self::Local(track) => track.rtc_track(),
+            Self::Remote(track) => track.rtc_track(),
         }
     }
 }

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -137,6 +137,6 @@ impl LocalVideoTrack {
     }
 
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
-        super::update_info(&self.inner, &&Track::LocalVideo(self.clone()), info);
+        super::update_info(&self.inner, &Track::LocalVideo(self.clone()), info);
     }
 }

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -179,10 +179,8 @@ pub(super) fn set_muted(inner: &Arc<TrackInner>, track: &Track, muted: bool) {
         if let Some(on_mute) = inner.events.muted.lock().as_ref() {
             on_mute(track.clone());
         }
-    } else {
-        if let Some(on_unmute) = inner.events.unmuted.lock().as_ref() {
-            on_unmute(track.clone());
-        }
+    } else if let Some(on_unmute) = inner.events.unmuted.lock().as_ref() {
+        on_unmute(track.clone());
     }
 }
 

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -115,10 +115,13 @@ impl Track {
 
 pub(super) use track_dispatch;
 
+type MutedHandler = Box<dyn Fn(Track) + Send>;
+type UnmutedHandler = Box<dyn Fn(Track) + Send>;
+
 #[derive(Default)]
 struct TrackEvents {
-    pub muted: Mutex<Option<Box<dyn Fn(Track) + Send>>>,
-    pub unmuted: Mutex<Option<Box<dyn Fn(Track) + Send>>>,
+    pub muted: Mutex<Option<MutedHandler>>,
+    pub unmuted: Mutex<Option<UnmutedHandler>>,
 }
 
 #[derive(Debug)]

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -188,8 +188,8 @@ pub(super) fn set_muted(inner: &Arc<TrackInner>, track: &Track, muted: bool) {
 
 pub(super) fn update_info(inner: &Arc<TrackInner>, _track: &Track, new_info: proto::TrackInfo) {
     let mut info = inner.info.write();
+    info.kind = TrackKind::try_from(new_info.r#type()).unwrap();
+    info.source = TrackSource::from(new_info.source());
     info.name = new_info.name;
     info.sid = new_info.sid.try_into().unwrap();
-    info.kind = TrackKind::try_from(proto::TrackType::from_i32(new_info.r#type).unwrap()).unwrap();
-    info.source = TrackSource::from(proto::TrackSource::from_i32(new_info.source).unwrap());
 }

--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -402,8 +402,8 @@ impl EngineInner {
             let subscriber_pc = handle.session.subscriber().peer_connection();
 
             last_info.join_response = handle.session.signal_client().join_response();
-            last_info.subscriber_offer = subscriber_pc.current_local_description();
-            last_info.subscriber_answer = subscriber_pc.current_remote_description();
+            last_info.subscriber_offer = subscriber_pc.current_remote_description();
+            last_info.subscriber_answer = subscriber_pc.current_local_description();
             last_info.data_channels_info = handle.session.data_channels_info();
         }
     }

--- a/livekit/src/rtc_engine/peer_transport.rs
+++ b/livekit/src/rtc_engine/peer_transport.rs
@@ -165,6 +165,7 @@ impl PeerTransport {
         }
 
         // TODO(theomonnom): Check that the target_os isn't wasm
+        // Not sure if this is really needed
         if options.ice_restart {
             self.peer_connection.restart_ice();
         }

--- a/livekit/src/rtc_engine/peer_transport.rs
+++ b/livekit/src/rtc_engine/peer_transport.rs
@@ -164,6 +164,11 @@ impl PeerTransport {
             }
         }
 
+        // TODO(theomonnom): Check that the target_os isn't wasm
+        if options.ice_restart {
+            self.peer_connection.restart_ice();
+        }
+
         let offer = self.peer_connection.create_offer(options).await?;
         self.peer_connection
             .set_local_description(offer.clone())

--- a/livekit/src/rtc_engine/peer_transport.rs
+++ b/livekit/src/rtc_engine/peer_transport.rs
@@ -71,7 +71,7 @@ impl PeerTransport {
     }
 
     pub fn signal_target(&self) -> proto::SignalTarget {
-        self.signal_target.clone()
+        self.signal_target
     }
 
     pub fn on_offer(&self, handler: Option<OnOfferCreated>) {

--- a/livekit/src/rtc_engine/rtc_events.rs
+++ b/livekit/src/rtc_engine/rtc_events.rs
@@ -147,7 +147,7 @@ pub fn forward_pc_events(transport: &mut PeerTransport, rtc_emitter: RtcEmitter)
             rtc_emitter.clone(),
         )));
 
-    transport.on_offer(Some(on_offer(signal_target, rtc_emitter.clone())));
+    transport.on_offer(Some(on_offer(signal_target, rtc_emitter)));
 }
 
 fn on_message(emitter: RtcEmitter) -> rtc::data_channel::OnMessage {
@@ -160,5 +160,5 @@ fn on_message(emitter: RtcEmitter) -> rtc::data_channel::OnMessage {
 }
 
 pub fn forward_dc_events(dc: &mut DataChannel, rtc_emitter: RtcEmitter) {
-    dc.on_message(Some(on_message(rtc_emitter.clone())));
+    dc.on_message(Some(on_message(rtc_emitter)));
 }

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -804,7 +804,6 @@ impl SessionInner {
                 .await?;
         }
 
-        self.wait_pc_connection().await?;
         self.signal_client.flush_queue().await;
         Ok(())
     }

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -15,7 +15,6 @@
 use std::env;
 use std::path;
 use std::process::Command;
-use webrtc_sys_build;
 
 fn main() {
     println!("cargo:rerun-if-env-changed=LK_DEBUG_WEBRTC");
@@ -94,7 +93,7 @@ fn main() {
     );
 
     for (key, value) in webrtc_sys_build::webrtc_defines() {
-        let value = value.as_ref().map(|v| v.as_str());
+        let value = value.as_deref();
         builder.define(key.as_str(), value);
     }
 

--- a/webrtc-sys/include/livekit/peer_connection.h
+++ b/webrtc-sys/include/livekit/peer_connection.h
@@ -92,6 +92,8 @@ class PeerConnection {
 
   void remove_track(std::shared_ptr<RtpSender> sender) const;
 
+  void restart_ice() const;
+
   std::shared_ptr<RtpTransceiver> add_transceiver(
       std::shared_ptr<MediaStreamTrack> track,
       RtpTransceiverInit init) const;

--- a/webrtc-sys/src/peer_connection.cpp
+++ b/webrtc-sys/src/peer_connection.cpp
@@ -144,6 +144,10 @@ void PeerConnection::set_remote_description(
   peer_connection_->SetRemoteDescription(desc->clone()->release(), observer);
 }
 
+void PeerConnection::restart_ice() const {
+  peer_connection_->RestartIce();
+}
+
 void PeerConnection::add_ice_candidate(
     std::shared_ptr<IceCandidate> candidate,
     rust::Box<AsyncContext> ctx,

--- a/webrtc-sys/src/peer_connection.rs
+++ b/webrtc-sys/src/peer_connection.rs
@@ -217,6 +217,7 @@ pub mod ffi {
             ctx: Box<AsyncContext>,
             on_complete: fn(ctx: Box<AsyncContext>, error: RtcError),
         );
+        fn restart_ice(self: &PeerConnection);
         fn current_local_description(self: &PeerConnection) -> UniquePtr<SessionDescription>;
         fn current_remote_description(self: &PeerConnection) -> UniquePtr<SessionDescription>;
         fn connection_state(self: &PeerConnection) -> PeerConnectionState;


### PR DESCRIPTION
- republish tracks on signal restart
- now using separate resume/restart events for PC & signal
- also fix migration sync states
- make clippy happier (sorry for the noises inside this PR)
- bridged PeerConnection::restart_ice 