### PR TITLE
ci: improved ffi builds 

### DIFF
--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -148,7 +148,9 @@ jobs:
       - name: Zip artifact (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
-          Compress-Archive -Path target\${{ matrix.target }}\release\${{ matrix.dylib }} livekit-ffi\include\livekit_ffi.h -DestinationPath ${{ github.workspace }}\${{ matrix.name }}.zip
+          cp livekit-ffi/include/livekit_ffi.h target/${{ matrix.target }}/release/
+          cd target/${{ matrix.target }}/release/
+          Get-ChildItem -Path ${{ matrix.dylib }}, livekit_ffi.h | Compress-Archive -DestinationPath ${{ github.workspace }}\${{ matrix.name }}.zip
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -17,6 +17,7 @@ on:
   push:
     branches: ["main"]
   workflow_dispatch:
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -27,40 +28,67 @@ jobs:
       matrix:
         include:
           - os: windows-latest
+            platform: windows
             dylib: livekit_ffi.dll
             target: x86_64-pc-windows-msvc
+            name: ffi-windows-x86_64
           - os: windows-latest
+            platform: windows
             dylib: livekit_ffi.dll
-            # due to ring 0.16 compatibilities with win aarch64, we need to use native-tls instead of rustls
-            buildargs: --no-default-features --features "native-tls" 
+            buildargs: --no-default-features --features "native-tls" # ring 0.16 is incompatible with win aarch64
             target: aarch64-pc-windows-msvc
+            name: ffi-windows-arm64
           - os: macos-latest
+            platform: macos
             dylib: liblivekit_ffi.dylib
             target: x86_64-apple-darwin
+            macosx_deployment_target: "10.11"
+            name: ffi-macos-x86_64
           - os: macos-latest
-            dylib: liblivekit_ffi.dylib
-            target: aarch64-apple-ios
-          - os: macos-latest
-            dylib: liblivekit_ffi.dylib
-            target: aarch64-apple-ios-sim
-          - os: macos-latest
+            platform: macos
             dylib: liblivekit_ffi.dylib
             target: aarch64-apple-darwin
-          - os: ubuntu-20.04
+            macosx_deployment_target: "11.0" # aarch64 requires 11
+            name: ffi-macos-arm64
+          - os: macos-latest
+            platform: ios
+            dylib: liblivekit_ffi.dylib
+            target: aarch64-apple-ios
+            iphoneos_deployment_target: "13.0"
+            name: ffi-ios-arm64
+          - os: macos-latest
+            platform: ios
+            dylib: liblivekit_ffi.dylib
+            target: aarch64-apple-ios-sim
+            iphoneos_deployment_target: "13.0"
+            name: ffi-ios-sim-arm64
+          - os: ubuntu-latest
+            platform: linux
+            build_image: quay.io/pypa/manylinux2014_x86_64
             dylib: liblivekit_ffi.so
             target: x86_64-unknown-linux-gnu
+            name: ffi-linux-x86_64
           - os: buildjet-4vcpu-ubuntu-2204-arm
+            platform: linux
+            build_image: quay.io/pypa/manylinux2014_aarch64
             dylib: liblivekit_ffi.so
             target: aarch64-unknown-linux-gnu
-          - os: ubuntu-20.04
+            name: ffi-linux-arm64
+          - os: ubuntu-latest
+            platform: android
             dylib: liblivekit_ffi.so
             target: aarch64-linux-android
-          - os: ubuntu-20.04
+            name: ffi-android-arm64
+          - os: ubuntu-latest
+            platform: android
             dylib: liblivekit_ffi.so
             target: armv7-linux-androideabi
-          - os: ubuntu-20.04
+            name: ffi-android-armv7
+          - os: ubuntu-latest
+            platform: android
             dylib: liblivekit_ffi.so
             target: x86_64-linux-android
+            name: ffi-android-x86_64
 
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
@@ -69,78 +97,62 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup vars
-        id: setup
-        run: |
-          echo "ZIP=liblivekit_ffi-${{ matrix.target }}.zip" >> "$GITHUB_OUTPUT"
-        shell: bash
-
-      - name: Info
-        run: |
-          echo "OutZip: ${{ steps.setup.outputs.ZIP }}"
-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: ${{ matrix.target }}
 
-      - name: Install linux dependencies
-        if: ${{ matrix.os == 'ubuntu-20.04' && matrix.target != 'aarch64-unknown-linux-gnu' }}
+      - name: Build (macOS)
+        if: ${{ matrix.platform == 'macos' }}
+        env:
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macosx_deployment_target }}
+        run: cd livekit-ffi && cargo build --release --target ${{ matrix.target }} ${{ matrix.buildargs }}
+
+      - name: Build (iOS)
+        if: ${{ matrix.platform == 'ios' }}
+        # TODO(theomonnom): Seems like this is causing issues with the linker (let’s ignore for now)
+        #env:
+        #  IPHONEOS_DEPLOYMENT_TARGET: ${{ matrix.iphoneos_deployment_target }}
+        run: cd livekit-ffi && cargo build --release --target ${{ matrix.target }} ${{ matrix.buildargs }}
+
+      - name: Build (Windows)
+        if: ${{ matrix.platform == 'windows' }}
+        run: cd livekit-ffi && cargo build --release --target ${{ matrix.target }} ${{ matrix.buildargs }}
+
+      # Use Docker on linux, so we can use manylinux images (ensure maximum mcompatibility)
+      - name: Build (Linux)
+        if: ${{ matrix.platform == 'linux' }}
         run: |
-          sudo apt update -y
-          sudo apt install -y libssl-dev libx11-dev libgl1-mesa-dev libxext-dev
+          docker run --rm -v $PWD:/workspace -w /workspace ${{ matrix.build_image }} bash -c "\
+            uname -a; \
+            export PATH=/root/.cargo/bin:\$PATH; \
+            yum install openssl-devel libX11-devel mesa-libGL-devel libXext-devel -y; \
+            curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; \
+            cd livekit-ffi && cargo build --release --target ${{ matrix.target }} ${{ matrix.buildargs }}"
 
-      - name: Set up QEMU
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to GitHub Container Registry
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build (Cargo)
-        if: ${{ !contains(matrix.target, 'android') && matrix.target != 'aarch64-unknown-linux-gnu' }}
-        run: | 
-          cd livekit-ffi/
-          cargo build --release --target ${{ matrix.target }} ${{ matrix.buildargs }}
-
-      - name: Build (Docker)
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        run: |
-          docker buildx create --use
-          docker buildx build --platform linux/arm64 --load -t lk-arm64:latest -f .github/aarch64-docker.dockerfile .
-          docker run --rm -v "$(pwd)":/usr/src/app -w /usr/src/app lk-arm64:latest sh -c 'cd livekit-ffi && cargo build --release --target aarch64-unknown-linux-gnu ${{ matrix.buildargs }}'
-
+      # on android use cargo ndk
       - name: Build (Android)
-        if: ${{ contains(matrix.target, 'android') }}
+        if: ${{ matrix.platform == 'android' }}
         run: |
           cd livekit-ffi/
           cargo install cargo-ndk
-          cargo ndk --target ${{ matrix.target }} build --release ${{ matrix.buildargs }} 
+          cargo ndk --target ${{ matrix.target }} build --release ${{ matrix.buildargs }}
 
+      # zip the files
       - name: Zip artifact (Unix)
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
-          cd target/${{ matrix.target }}/release/
-          zip ${{ github.workspace }}/${{ steps.setup.outputs.ZIP }} ${{ matrix.dylib }}
+          zip ${{ github.workspace }}/${{ matrix.name }}.zip target/${{ matrix.target }}/release/${{ matrix.dylib }} \
+            livekit-ffi/include/livekit_ffi.h
 
       - name: Zip artifact (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
-          cd target/${{ matrix.target }}/release/
-          Compress-Archive -Path ${{ matrix.dylib }} -DestinationPath  ${{ github.workspace }}\${{ steps.setup.outputs.ZIP }}
+          Compress-Archive -Path target\${{ matrix.target }}\release\${{ matrix.dylib }} \
+            livekit-ffi\include\livekit_ffi.h -DestinationPath ${{ github.workspace }}\${{ matrix.name }}.zip
 
-      # doublezip here but I don't think there is an alternative
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.setup.outputs.ZIP }}
-          path: ${{ steps.setup.outputs.ZIP }}
+          name: ${{ matrix.name }}.zip
+          path: ${{ matrix.name }}.zip

--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -148,8 +148,7 @@ jobs:
       - name: Zip artifact (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
-          Compress-Archive -Path target\${{ matrix.target }}\release\${{ matrix.dylib }} \
-            livekit-ffi\include\livekit_ffi.h -DestinationPath ${{ github.workspace }}\${{ matrix.name }}.zip
+          Compress-Archive -Path target\${{ matrix.target }}\release\${{ matrix.dylib }} livekit-ffi\include\livekit_ffi.h -DestinationPath ${{ github.workspace }}\${{ matrix.name }}.zip
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
- explicit deployment target for macos
- better library naming
- use [manylinux](https://github.com/pypa/manylinux) (increase linux compatibility). good practice from the Python community
  - currently using `manylinux2014`
  
  
 related PR was #147 but it was not sufficient