### PR TITLE
fix: support non-utf8 std::string which can come e.g. from Windows message errors

### DIFF
--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -161,7 +161,7 @@ LogSink::~LogSink() {
 
 void LogSink::OnLogMessage(const std::string& message,
                            rtc::LoggingSeverity severity) {
-  fnc_(rust::String(message), static_cast<LoggingSeverity>(severity));
+  fnc_(rust::String::lossy(message), static_cast<LoggingSeverity>(severity));
 }
 
 std::unique_ptr<LogSink> new_log_sink(


### PR DESCRIPTION
Fix https://github.com/livekit/client-sdk-rust/issues/192