### PR TITLE
fix: participant updates

### DIFF
--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -311,6 +311,8 @@ impl RoomInner {
                     if inner.pending_unpublished_tracks.lock().remove(&sid) {
                         break; // Event was sent
                     }
+
+                    log::info!("waiting for the LocalTrackUnpublished event to be sent");
                     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                 }
             }
@@ -432,6 +434,7 @@ async fn forward_event(server: &'static FfiServer, inner: &Arc<RoomInner>, event
                 if inner.pending_published_tracks.lock().remove(&sid) {
                     break;
                 }
+                log::info!("waiting for the PublishTrack callback to be sent");
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
             }
 

--- a/livekit/src/room/publication/remote.rs
+++ b/livekit/src/room/publication/remote.rs
@@ -196,7 +196,6 @@ impl RemoteTrackPublication {
         *self.remote.events.unsubscribed.lock() = Some(Box::new(f));
     }
 
-    #[allow(dead_code)]
     pub(crate) fn on_subscription_status_changed(
         &self,
         f: impl Fn(RemoteTrackPublication, SubscriptionStatus, SubscriptionStatus) + Send + 'static,
@@ -204,7 +203,6 @@ impl RemoteTrackPublication {
         *self.remote.events.subscription_status_changed.lock() = Some(Box::new(f));
     }
 
-    #[allow(dead_code)]
     pub(crate) fn on_permission_status_changed(
         &self,
         f: impl Fn(RemoteTrackPublication, PermissionStatus, PermissionStatus) + Send + 'static,


### PR DESCRIPTION
 - Handle the case a remote participant Sid can change
 - Don't create a new participant if the state of the new one is already disconnected (e.g)
 
` [2023-09-25T23:23:31Z INFO  livekit::room] participant update: [ParticipantInfo { sid: "PA_3DH5jgnRV8NA", identity: "client", state: Disconnected, tracks: [], metadata: "", joined_at: 1695684209, name: "", version: 3, permission: Some(ParticipantPermission { can_subscribe: true, can_publish: true, can_publish_data: true, can_publish_sources: [], hidden: false, recorder: false, can_update_metadata: false }), region: "sfo3", is_publisher: false }]`