### PR TITLE
fix: tasks being stuck while closing the PC

### DIFF
--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -245,10 +245,13 @@ impl RtcSession {
     /// Close the PeerConnections and the SignalClient
     pub async fn close(self) {
         // Close the tasks
-        self.inner.close().await;
         let _ = self.close_tx.send(true);
         let _ = self.rtc_task.await;
         let _ = self.signal_task.await;
+
+        // Close the PeerConnections after the task
+        // So if a sensitive operation is running, we can wait for it
+        self.inner.close().await;
     }
 
     pub async fn publish_data(


### PR DESCRIPTION
- It seems that SetRemoteDescription gets into a stuck state if we try to close the peer connections at the same time?

cc @cloudwebrtc 